### PR TITLE
Lazy-loading service

### DIFF
--- a/app/components/follow-button/component.js
+++ b/app/components/follow-button/component.js
@@ -12,6 +12,7 @@ export default Component.extend({
 
   session: service(),
   store: service(),
+  lazy: service(),
   isFollowing: notEmpty('relationship'),
 
   didAuthenticate: observer('session.account', function() {
@@ -19,11 +20,21 @@ export default Component.extend({
   }),
 
   getFollowStatus: task(function* () {
+    const lookFor = {
+      follower: get(this, 'session.account.id'),
+      followed: get(this, 'user.id')
+    };
+
+    if (get(this, 'lazyId') !== undefined) {
+      return yield get(this, 'lazy.add').perform(get(this, 'lazyId'), lookFor).then(() => {
+        const payload = get(this, 'lazy').fetch(get(this, 'lazyId'));
+        const rel = payload.find(item => (get(item, 'followed.id') === lookFor.followed));
+        set(this, 'relationship', rel);
+      });
+    }
+
     return yield get(this, 'store').query('follow', {
-      filter: {
-        follower: get(this, 'session.account.id'),
-        followed: get(this, 'user.id')
-      }
+      filter: lookFor
     }).then(follow => set(this, 'relationship', get(follow, 'firstObject')));
   }),
 

--- a/app/routes/users/following/controller.js
+++ b/app/routes/users/following/controller.js
@@ -1,7 +1,19 @@
 import Controller from 'ember-controller';
 import service from 'ember-service/inject';
+import get from 'ember-metal/get';
+import set from 'ember-metal/set';
 import IsOwnerMixin from 'client/mixins/is-owner';
 
 export default Controller.extend(IsOwnerMixin, {
-  session: service()
+  session: service(),
+  lazy: service(),
+
+  modelSizeChanged: function() {
+    get(this, 'lazy').setTreshold(get(this, 'lazyId'), get(this, 'model.length'));
+  }.observes('model.length'),
+
+  init() {
+    this._super(...arguments);
+    set(this, 'lazyId', get(this, 'lazy').create('follow', 'followed'));
+  }
 });

--- a/app/routes/users/following/template.hbs
+++ b/app/routes/users/following/template.hbs
@@ -6,7 +6,7 @@
         <h4 class="card-title">{{follow.followed.name}}</h4>
         <p class="card-text">{{follow.followed.about}}</p>
         {{#if (not (is-self follow.followed))}}
-          {{follow-button user=follow.followed}}
+          {{follow-button user=follow.followed lazyId=lazyId}}
         {{/if}}
       </div>
     </div>

--- a/app/services/lazy.js
+++ b/app/services/lazy.js
@@ -58,7 +58,7 @@ export default Ember.Service.extend({
       if (key !== multikey) finalFilter[key] = reference[key];
     });
 
-    for (let i = get(this, 'preloaded'); i < get(this, 'threshold'); i += 1) {
+    for (let i = collection.preloaded; i < collection.threshold; i += 1) {
       const filter = collection.targets.objectAt(i);
       if (filter === undefined) break;
 

--- a/app/services/lazy.js
+++ b/app/services/lazy.js
@@ -1,0 +1,85 @@
+import Ember from 'ember';
+import get from 'ember-metal/get';
+import set from 'ember-metal/set';
+import { task } from 'ember-concurrency';
+import service from 'ember-service/inject';
+import RSVP from 'rsvp';
+
+export default Ember.Service.extend({
+  store: service(),
+
+  collections: null,
+
+  create(resource, multikey, include = null) {
+    const collection = { targets: [] };
+
+    if (include !== null) collection.include = include;
+    collection.resource = resource;
+    collection.multikey = multikey;
+    collection.threshold = 0;
+    collection.preloaded = 0;
+    collection.waiting = [];
+
+    get(this, 'collections').pushObject(collection);
+    return (get(this, 'collections').length - 1);
+  },
+
+  add: task(function* (collectionId, target) {
+    const collection = get(this, 'collections').objectAt(collectionId);
+    collection.targets.addObject(target);
+
+    if (collection.targets.length >= collection.threshold) {
+      return yield get(this, 'resolve').perform(collectionId);
+    }
+
+    return yield get(this, 'await').perform(collectionId);
+  }),
+
+  await: task(function* (collectionId) {
+    yield new RSVP.Promise((resolve) => {
+      get(this, 'collections').objectAt(collectionId).waiting.addObject(resolve);
+    });
+  }),
+
+  delete(collectionId) {
+    get(this, 'collections').removeAt(collectionId);
+  },
+
+  resolve: task(function* (collectionId) {
+    const collection = get(this, 'collections').objectAt(collectionId);
+    const reference = collection.targets.objectAt(0);
+    const multikey = collection.multikey;
+    const finalFilter = {};
+    finalFilter[multikey] = [];
+
+    for (const key in reference) {
+      if (key !== multikey) finalFilter[key] = reference[key];
+    }
+
+    for (const filter of collection.targets) {
+      finalFilter[multikey].addObject(filter[multikey]);
+    }
+
+    return yield get(this, 'store').query(collection.resource, {
+      filter: finalFilter,
+      include: get(this, 'include')
+    }).then((payload) => {
+      collection.payload = payload;
+      collection.preloaded = collection.threshold;
+      collection.waiting.forEach(resolver => resolver());
+    });
+  }),
+
+  fetch(collectionId) {
+    return get(this, 'collections').objectAt(collectionId).payload;
+  },
+
+  setTreshold(collectionId, threshold) {
+    get(this, 'collections').objectAt(collectionId).threshold = threshold;
+  },
+
+  init() {
+    this._super(...arguments);
+    set(this, 'collections', []);
+  }
+});


### PR DESCRIPTION
The idea of this service is to allow lazy loading for components that require small amounts of data. The concept behind it is fairly simple.
- In the page's controller, a new lazy loading collection will be initialized by loading the `lazy` service and calling `lazy.create`, which returns the ID of the new collection.
  - If the controller has pagination/infinite loading, an observer to `model.length` can be registered in order to change the service's request threshold when loading more data via `lazy.setThreshold`
- In the template, every component is passed the `lazyId` that was passed back to the controlelr from `lazy.create`
- In the component, the only thing that has to be changed is the inital data loading loop.
  - If `lazyId` is not set, the component will load data as usual.
-  If it is set, the component will add its filter via `lazy.add` and use its callback to get the received payload and filter the information it needs. The promise returned by `lazy.add` will only be resolved after the threshold is reached and all data is bulk-loaded, leaving the component in its inital loading state.

Things that need to be done:
- Move this into a module, so we don't have to care about teardown on page change
- Refactor `init` and `filter` so that this can be used like a normal store call

Thoughts on this solution? 🐗  @vevix 
