### PR TITLE
Update noUiSlider styles

### DIFF
--- a/app/styles/vendor/noui.scss
+++ b/app/styles/vendor/noui.scss
@@ -2,6 +2,7 @@
  * Browsers can paint handles in their own layer.
  */
 .noUi-base {
+  left: 7px;
   transform: translate3d(0,0,0);
   background-color: #383D48;
   border-radius: 999em;
@@ -49,9 +50,6 @@
 }
 .noUi-horizontal .noUi-handle:before {
   display: none;
-}
-.noUi-horizontal .noUi-handle-lower {
-  left: 0px;
 }
 
 /* Styling;


### PR DESCRIPTION
Update noUiSlider styling

Related to: Explore page slider's 0 value position is to the left of the min value circle when moving the max value circle to it (chrome) https://gfycat.com/ResponsibleTiredAnaconda

4th checkbox under unsorted bugs.

Reason: putting `padding: 10px` under `filter-widget` was breaking the noUiSlider.
In addition, adding `.noUi-horizontal .noUi-handle-lower { left: 0px; }`ignores the default `left: -14px` which was falsely placing the slider handle.