### PR TITLE
Prevent highlighting media filter + noUi pointer cursor

### DIFF
--- a/app/styles/pages/_media-browse.scss
+++ b/app/styles/pages/_media-browse.scss
@@ -1,3 +1,8 @@
+.noUi-handle,
+.noUi-target {
+  cursor: pointer;
+}
+
 .browse-page {
   padding-top: 0;
   .global-container {
@@ -26,6 +31,8 @@
     padding: 0;
     padding-top: 20px;
     bottom: 0;
+    user-select: none;
+    cursor: default;
     @media (max-width: 768px) {
       display: none;
     }


### PR DESCRIPTION
Prevents the unexpected behaviour of:
![](https://i.imgur.com/4CZJ78R.png)

Sliders now indicate they're selectable, were just normal cursor.
![](http://i.imgur.com/zTeS6sg.png)