### PR TITLE
Improve search results

### DIFF
--- a/app/components/application/site-search/group.js
+++ b/app/components/application/site-search/group.js
@@ -1,12 +1,7 @@
 import Component from 'ember-component';
-import { invokeAction } from 'ember-invoke-action';
 
 export default Component.extend({
   actions: {
-    close() {
-      invokeAction(this, 'close');
-    },
-
     noop() { }
   }
 });

--- a/app/components/application/site-search/group.js
+++ b/app/components/application/site-search/group.js
@@ -1,26 +1,10 @@
 import Component from 'ember-component';
-import get from 'ember-metal/get';
-import service from 'ember-service/inject';
-import { typeOf } from 'ember-utils';
 import { invokeAction } from 'ember-invoke-action';
-import { modelType } from 'client/helpers/model-type';
 
 export default Component.extend({
-  router: service('-routing'),
-
   actions: {
-    transitionTo(item) {
+    close() {
       invokeAction(this, 'close');
-      if (typeOf(item) === 'string') {
-        get(this, 'router.router').transitionTo(item);
-      } else {
-        const type = modelType([item]);
-        if (type === 'user') {
-          get(this, 'router').transitionTo('users.index', [item]);
-        } else {
-          get(this, 'router').transitionTo(`${type}.show`, [item]);
-        }
-      }
     },
 
     noop() { }

--- a/app/components/application/site-search/group/item.js
+++ b/app/components/application/site-search/group/item.js
@@ -1,28 +1,26 @@
-import Ember from 'ember';
+import Component from 'ember-component';
 import get from 'ember-metal/get';
-import computed from 'ember-computed';
+import getter from 'client/utils/getter';
 import service from 'ember-service/inject';
 import { typeOf } from 'ember-utils';
 import { modelType } from 'client/helpers/model-type';
 import { hrefTo } from 'ember-href-to/helpers/href-to';
 import { invokeAction } from 'ember-invoke-action';
 
-export default Ember.Component.extend({
+export default Component.extend({
   router: service('-routing'),
 
-  link: computed('item', {
-    get() {
-      const item = get(this, 'item');
-      if (typeOf(item) === 'string') {
-        return item;
-      }
-
-      const type = modelType([item]);
-      if (type === 'user') {
-        return hrefTo(this, 'users.index', get(item, 'id'));
-      }
-      return hrefTo(this, `${type}.show`, get(item, 'id'));
+  link: getter(function() {
+    const item = get(this, 'item');
+    if (typeOf(item) === 'string') {
+      return item;
     }
+
+    const type = modelType([item]);
+    if (type === 'user') {
+      return hrefTo(this, 'users.index', get(item, 'id'));
+    }
+    return hrefTo(this, `${type}.show`, get(item, 'id'));
   }),
 
   actions: {

--- a/app/components/application/site-search/group/item.js
+++ b/app/components/application/site-search/group/item.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import get from 'ember-metal/get';
+import computed from 'ember-computed';
+import service from 'ember-service/inject';
+import { typeOf } from 'ember-utils';
+import { modelType } from 'client/helpers/model-type';
+import { hrefTo } from 'ember-href-to/helpers/href-to';
+import { invokeAction } from 'ember-invoke-action';
+
+export default Ember.Component.extend({
+  router: service('-routing'),
+
+  link: computed('item', {
+    get() {
+      const item = get(this, 'item');
+      if (typeOf(item) === 'string') {
+        return item;
+      }
+
+      const type = modelType([item]);
+      if (type === 'user') {
+        return hrefTo(this, 'users.index', get(item, 'id'));
+      }
+      return hrefTo(this, `${type}.show`, get(item, 'id'));
+    }
+  }),
+
+  actions: {
+    transitionTo(link) {
+      invokeAction(this, 'close');
+      get(this, 'router.router').transitionTo(link);
+    }
+  }
+});

--- a/app/templates/components/application/site-search/group.hbs
+++ b/app/templates/components/application/site-search/group.hbs
@@ -29,22 +29,7 @@
   {{else}}
     <ul class="media-list search--results">
       {{#each items as |item|}}
-        <li class="media col-sm-12" {{action "transitionTo" item}}>
-          <div class="media-left col-sm-2 no-padding-left">
-            {{#if (eq group "users")}}
-              {{lazy-image url=(image item.avatar "small")}}
-            {{else}}
-              {{lazy-image url=(image item.posterImage "small")}}
-            {{/if}}
-          </div>
-          <div class="media-body col-sm no-padding-left">
-            {{#if (eq group "users")}}
-              <p>{{item.name}}</p>
-            {{else}}
-              <p>{{item.computedTitle}}</p>
-            {{/if}}
-          </div>
-        </li>
+        {{application/site-search/group/item item=item close=(action "close")}}
       {{/each}}
     </ul>
   {{/if}}

--- a/app/templates/components/application/site-search/group.hbs
+++ b/app/templates/components/application/site-search/group.hbs
@@ -29,7 +29,7 @@
   {{else}}
     <ul class="media-list search--results">
       {{#each items as |item|}}
-        {{application/site-search/group/item item=item close=(action "close")}}
+        {{application/site-search/group/item item=item close=close}}
       {{/each}}
     </ul>
   {{/if}}

--- a/app/templates/components/application/site-search/group/item.hbs
+++ b/app/templates/components/application/site-search/group/item.hbs
@@ -1,14 +1,14 @@
 <li class="media col-sm-12">
   <a class="search--result-link" href="{{link}}" {{action "transitionTo" link}}>
     <div class="media-left col-sm-2 no-padding-left">
-      {{#if (eq group "users")}}
+      {{#if (eq (model-type item) "user")}}
         {{lazy-image url=(image item.avatar "small")}}
       {{else}}
         {{lazy-image url=(image item.posterImage "small")}}
       {{/if}}
     </div>
     <div class="media-body col-sm no-padding-left">
-      {{#if (eq group "users")}}
+      {{#if (eq (model-type item) "user")}}
         <p>{{item.name}}</p>
       {{else}}
         <p>{{item.computedTitle}}</p>

--- a/app/templates/components/application/site-search/group/item.hbs
+++ b/app/templates/components/application/site-search/group/item.hbs
@@ -1,0 +1,18 @@
+<li class="media col-sm-12">
+  <a class="search--result-link" href="{{link}}" {{action "transitionTo" link}}>
+    <div class="media-left col-sm-2 no-padding-left">
+      {{#if (eq group "users")}}
+        {{lazy-image url=(image item.avatar "small")}}
+      {{else}}
+        {{lazy-image url=(image item.posterImage "small")}}
+      {{/if}}
+    </div>
+    <div class="media-body col-sm no-padding-left">
+      {{#if (eq group "users")}}
+        <p>{{item.name}}</p>
+      {{else}}
+        <p>{{item.computedTitle}}</p>
+      {{/if}}
+    </div>
+  </a>
+</li>


### PR DESCRIPTION
This PR componentizes search result items and allow opening them in new tabs. Upon clicking a result, the dropdown will close like normal, however, when opening a result in a new tab, the dropdown will stay, assuming you want to open other entries as well.

- [x] Componentize search results
- [x] Refactor search results to use `href-to`to allow opening them in in new tabs
- [ ] Style new linked search results @JoshFabian 
- [ ] Add additional information to search results  @JoshFabian / @cybrox