### PR TITLE
Fix overriding Controller data on tasks

### DIFF
--- a/app/routes/admin/reports/closed.js
+++ b/app/routes/admin/reports/closed.js
@@ -6,15 +6,13 @@ import PaginationMixin from 'client/mixins/routes/pagination';
 
 export default Route.extend(PaginationMixin, {
   modelTask: task(function* () {
-    return yield get(this, 'store').query('report', {
+    const results = yield get(this, 'store').query('report', {
       include: 'user,naughty,moderator',
       filter: { status: '1,2' },
       page: { limit: 20 }
-    }).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
     });
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }),
 
   model() {

--- a/app/routes/admin/reports/index.js
+++ b/app/routes/admin/reports/index.js
@@ -6,15 +6,13 @@ import PaginationMixin from 'client/mixins/routes/pagination';
 
 export default Route.extend(PaginationMixin, {
   modelTask: task(function* () {
-    return yield get(this, 'store').query('report', {
+    const results = yield get(this, 'store').query('report', {
       include: 'user,naughty,moderator',
       filter: { status: 0 },
       page: { limit: 20 }
-    }).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
     });
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }),
 
   model() {

--- a/app/routes/media/index.js
+++ b/app/routes/media/index.js
@@ -25,11 +25,9 @@ export default Route.extend(SlideHeaderMixin, QueryableMixin, PaginationMixin, {
   }).restartable(),
 
   modelTask: task(function* (mediaType, options) {
-    return yield get(this, 'store').query(mediaType, options).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
-    });
+    const results = yield get(this, 'store').query(mediaType, options);
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }).restartable(),
 
   init() {

--- a/app/routes/media/show/episodes.js
+++ b/app/routes/media/show/episodes.js
@@ -11,16 +11,14 @@ export default Route.extend(PaginationMixin, {
   modelTask: task(function* () {
     const [mediaType] = get(this, 'routeName').split('.');
     const media = this.modelFor(`${mediaType}.show`);
-    return yield get(this, 'store').query('episode', {
+    const results = yield get(this, 'store').query('episode', {
       filter: {
         media_type: capitalize(mediaType),
         media_id: get(media, 'id')
       }
-    }).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
     });
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }),
 
   model() {

--- a/app/routes/media/show/reviews.js
+++ b/app/routes/media/show/reviews.js
@@ -12,18 +12,16 @@ export default Route.extend(PaginationMixin, {
   modelTask: task(function* () {
     const parentRoute = get(this, 'routeName').split('.').slice(0, 2).join('.');
     const media = this.modelFor(parentRoute);
-    return yield get(this, 'store').query('review', {
+    const results = yield get(this, 'store').query('review', {
       include: 'user,media',
       filter: {
         media_type: capitalize(modelType([media])),
         media_id: get(media, 'id')
       },
       sort: '-likes_count'
-    }).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
     });
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }),
 
   model() {

--- a/app/routes/settings/blocking.js
+++ b/app/routes/settings/blocking.js
@@ -9,11 +9,9 @@ export default Route.extend(PaginationMixin, {
   session: service(),
 
   modelTask: task(function* () {
-    return yield get(this, 'store').findAll('block', { include: 'blocked' }).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
-    });
+    const results = yield get(this, 'store').findAll('block', { include: 'blocked' });
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }),
 
   model() {

--- a/app/routes/settings/imports.js
+++ b/app/routes/settings/imports.js
@@ -5,11 +5,9 @@ import { task } from 'ember-concurrency';
 
 export default Route.extend({
   modelTask: task(function* () {
-    return yield get(this, 'store').findAll('list-import').then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
-    });
+    const results = yield get(this, 'store').findAll('list-import');
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }),
 
   model() {

--- a/app/routes/users/followers.js
+++ b/app/routes/users/followers.js
@@ -9,15 +9,13 @@ export default Route.extend(PaginationMixin, {
   i18n: service(),
 
   modelTask: task(function* (user) {
-    return yield get(this, 'store').query('follow', {
+    const results = yield get(this, 'store').query('follow', {
       filter: { followed: get(user, 'id') },
       include: 'follower',
       sort: '-created_at'
-    }).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
     });
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }),
 
   model() {

--- a/app/routes/users/following.js
+++ b/app/routes/users/following.js
@@ -9,15 +9,13 @@ export default Route.extend(PaginationMixin, {
   i18n: service(),
 
   modelTask: task(function* (user) {
-    return yield get(this, 'store').query('follow', {
+    const results = yield get(this, 'store').query('follow', {
       filter: { follower: get(user, 'id') },
       include: 'followed',
       sort: '-created_at'
-    }).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
     });
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }),
 
   model() {

--- a/app/routes/users/library.js
+++ b/app/routes/users/library.js
@@ -48,11 +48,9 @@ export default Route.extend(PaginationMixin, {
       },
       page: { offset: 0, limit: 200 }
     });
-    return yield get(this, 'store').query('library-entry', options).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
-    });
+    const entries = yield get(this, 'store').query('library-entry', options);
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', entries);
   }).restartable(),
 
   beforeModel({ queryParams }) {

--- a/app/routes/users/reviews.js
+++ b/app/routes/users/reviews.js
@@ -9,16 +9,14 @@ export default Route.extend(PaginationMixin, {
   i18n: service(),
 
   modelTask: task(function* (user) {
-    return yield get(this, 'store').query('review', {
+    const results = yield get(this, 'store').query('review', {
       include: 'user,media',
       filter: {
         user_id: get(user, 'id')
       }
-    }).then((results) => {
-      const controller = this.controllerFor(get(this, 'routeName'));
-      set(controller, 'taskValue', results);
-      return results;
     });
+    const controller = this.controllerFor(get(this, 'routeName'));
+    set(controller, 'taskValue', results);
   }),
 
   model() {

--- a/app/templates/media/index.hbs
+++ b/app/templates/media/index.hbs
@@ -260,7 +260,7 @@
           {{/if}}
         </div>
 
-        {{#if (and model.taskInstance.value (not model.taskInstance.isRunning))}}
+        {{#if (and taskValue (not model.taskInstance.isRunning))}}
           <div class="m-t-1 text-xs-center">
             {{paginated-resource/infinite
               model=taskValue

--- a/app/templates/media/index.hbs
+++ b/app/templates/media/index.hbs
@@ -227,8 +227,13 @@
             <span class="tag-name">Year</span>
             <a class="tag-remove"></a>
           --}}
-          {{search-input class="search-media tag-input" icon=true text=text update=(action (mut text)) placeholder=(t
-            "media.routes.index.filter.search") }}
+          {{search-input
+            class="search-media tag-input"
+            icon=true
+            text=text
+            update=(action (mut text))
+            placeholder=(t "media.routes.index.filter.search")
+          }}
         </div>
       </div>
 
@@ -244,7 +249,7 @@
             <div class="text-xs-center w-100 m-t-1">
               {{t "errors.load"}}
             </div>
-          {{else if model.taskInstance.value}}
+          {{else if taskValue}}
             {{#each taskValue as |media|}}
               {{media/media-poster media=media}}
             {{/each}}

--- a/app/templates/media/show/episodes.hbs
+++ b/app/templates/media/show/episodes.hbs
@@ -7,7 +7,7 @@
   <div class="text-xs-center w-100 m-t-1 m-b-1">
     {{t "errors.load"}}
   </div>
-{{else if model.taskInstance.value}}
+{{else if taskValue}}
   <ul class="media--episode-grid row">
     {{#each taskValue as |episode|}}
       <li class="media--episode-block col-md-4 col-sm-2">

--- a/app/templates/media/show/reviews.hbs
+++ b/app/templates/media/show/reviews.hbs
@@ -7,7 +7,7 @@
   <div class="text-xs-center w-100 m-t-1 m-b-1">
     {{t "errors.load"}}
   </div>
-{{else if model.taskInstance.value}}
+{{else if taskValue}}
   <ul class="media-list w-100">
     {{! TODO @Josh - Reviews on the media page `/anime/sword-art-online/reviews` }}
     {{#each taskValue as |review|}}

--- a/app/templates/settings/blocking.hbs
+++ b/app/templates/settings/blocking.hbs
@@ -35,7 +35,7 @@
     <div class="text-xs-center w-100 m-t-1 m-b-1">
       {{t "errors.load"}}
     </div>
-  {{else if model.taskInstance.value}}
+  {{else if taskValue}}
     <div class="form-group row">
       <ul class="blocked-user--list">
         {{#each taskValue as |block|}}

--- a/app/templates/settings/imports.hbs
+++ b/app/templates/settings/imports.hbs
@@ -33,7 +33,7 @@
       <div class="text-xs-center w-100 m-t-1 m-b-1">
         {{t "errors.load"}}
       </div>
-    {{else if model.taskInstance.value}}
+    {{else if taskValue}}
       <div id="accordian" class="w-100">
         {{#each taskValue as |import index|}}
           <div class="card">

--- a/app/templates/users/followers.hbs
+++ b/app/templates/users/followers.hbs
@@ -9,7 +9,7 @@
       <div class="text-xs-center w-100 m-t-1 m-b-1">
         {{t "errors.load"}}
       </div>
-    {{else if model.taskInstance.value}}
+    {{else if taskValue}}
       {{#each taskValue as |follow|}}
         {{#if follow.follower}}
           <div class="card user-card col-sm-3">

--- a/app/templates/users/following.hbs
+++ b/app/templates/users/following.hbs
@@ -9,7 +9,7 @@
       <div class="text-xs-center w-100 m-t-1 m-b-1">
         {{t "erros.load"}}
       </div>
-    {{else if model.taskInstance.value}}
+    {{else if taskValue}}
       {{#each taskValue as |follow|}}
         {{#if follow.followed}}
           <div class="card user-card col-sm-3">

--- a/app/templates/users/reviews.hbs
+++ b/app/templates/users/reviews.hbs
@@ -8,7 +8,7 @@
     <div class="text-xs-center w-100 m-t-1">
       {{t "errors.load"}}
     </div>
-  {{else if model.taskInstance.value}}
+  {{else if taskValue}}
     <ul class="media-list w-100">
       {{! TODO @Josh - Reviews on the users page `/users/Josh/reviews` }}
       {{#each taskValue as |review|}}


### PR DESCRIPTION
Fixes hummingbird-me/hummingbird#778.

Problem was that `ember-concurrency` cancels the task but does not cancel the in flight AJAX request so the thenable on the promise was executing regardless and replacing the controller's property.

This fixes that as the code after the `yield` won't execute on a canceled task but we should still look into canceling in flight requests to save bandwidth for the consumer.

I'll open up a new issue on the meta repository with details on an implementation for that later tonight.