### PR TITLE
Decrease transition delay for library entries

### DIFF
--- a/app/styles/pages/_library.scss
+++ b/app/styles/pages/_library.scss
@@ -203,7 +203,7 @@
   cursor: pointer;
   border-bottom: 1px solid $eggshell;
   line-height: 40px;
-  transition: .3s ease-in-out;
+  transition: .1s ease-in-out;
   @media (max-width: 992px) {
     padding-bottom: 0;
     padding-top: 20px;


### PR DESCRIPTION
.3s makes the library page appear slower than it actually is.