### PR TITLE
Fix bottom border radius of quick update overlay

### DIFF
--- a/app/styles/layout/_quick-update.scss
+++ b/app/styles/layout/_quick-update.scss
@@ -76,7 +76,6 @@
       background-image: linear-gradient(rgba(0,0,0,0.1), rgba(0,0,0,0.7) 50%, rgba(0,0,0,0.7) 100%);
       background-size: auto 200%;
       background-repeat: repeat-x;
-      border-radius: 3px;
       text-align: center;
       position: absolute;
       top: 0;


### PR DESCRIPTION
Fixes the gap between the border radius of each cover in the quick update and the border radius of the dark overlay.

Some say a picture is worth a thousand words, so before:
![](http://i.imgur.com/nsy7WU2.png)

And after:
![](http://i.imgur.com/97l06Iv.png)
