### PR TITLE
Add more locales for international titles

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -141,6 +141,12 @@ export default {
           en_us: 'English',
           en_jp: 'Romanized',
           ja_jp: 'Japanese',
+          en_cn: 'Romanized',
+          zh_cn: 'Chinese',
+          en_th: 'Romanized',
+          tn_th: 'Thai',
+          en_kr: 'Romanized',
+          ko_kr: 'Korean',
           synonyms: 'Synonyms'
         },
         information: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -144,7 +144,7 @@ export default {
           en_cn: 'Romanized',
           zh_cn: 'Chinese',
           en_th: 'Romanized',
-          tn_th: 'Thai',
+          th_th: 'Thai',
           en_kr: 'Romanized',
           ko_kr: 'Korean',
           synonyms: 'Synonyms'


### PR DESCRIPTION
Adds the following locales for titles:

 * Thai
 * Chinese
 * Korean

afaik only Chinese is in usage [for Black Cat Detective](https://kitsu.io/anime/hei-mao-jing-zhang), but dramas will require the others (so I figured I'd add 'em too)