### PR TITLE
Fix grid cutoff on mobile explore pages

### DIFF
--- a/app/styles/pages/_media-browse.scss
+++ b/app/styles/pages/_media-browse.scss
@@ -65,6 +65,11 @@
       @media (max-width: 768px) {
         padding: 75px 0 75px 0;
       }
+      .row {
+        @media (max-width: 768px) {
+          margin-left: 0;
+        }
+      }
     }
     .poster-wrapper {
       float: left;


### PR DESCRIPTION
Before|After
---|---
![](https://puu.sh/tND5C/ab9714fbdd.png)|![](https://puu.sh/tND6L/8b6e854eaa.png)
