### PR TITLE
Style fixes 2

### DIFF
--- a/app/styles/layout/_login-register-modal.scss
+++ b/app/styles/layout/_login-register-modal.scss
@@ -199,6 +199,7 @@
 
 .import-title {
   color: $charcoal;
+  display: inline-block;
 }
 
 .onboarding-search {

--- a/app/styles/layout/_modals.scss
+++ b/app/styles/layout/_modals.scss
@@ -60,6 +60,12 @@
   padding: 15px;
 }
 
+.modal-dialog {
+  @media (max-width: 544px) {
+    margin: 20px;
+  }
+}
+
 .modal-wrapper {
   padding: 20px;
   padding-top: 5px;

--- a/app/styles/pages/_library.scss
+++ b/app/styles/pages/_library.scss
@@ -157,6 +157,9 @@
     display: inline-block;
     height: 100%;
     border-right: 1px solid #ddd;
+    @media (max-width: 992px) {
+      padding-right: 5px;
+    }
     .entry-rating-star {
       position: relative;
       top: 4px;

--- a/app/styles/pages/_library.scss
+++ b/app/styles/pages/_library.scss
@@ -319,6 +319,8 @@
   .drop-thumb {
     max-width: 100%;
     border-radius: 3px;
+    width: 40px;
+    height: 40px;
   }
   .drop-title {
     font-size: 18px;

--- a/app/styles/pages/_library.scss
+++ b/app/styles/pages/_library.scss
@@ -182,10 +182,6 @@
   overflow: hidden;
   margin-right: 15px;
   border-radius: 3px;
-  img {
-    width: 40px;
-    height: 40px;
-  }
 }
 
 .entry-indicators {

--- a/app/styles/pages/_media-browse.scss
+++ b/app/styles/pages/_media-browse.scss
@@ -64,6 +64,7 @@
       //height: 100vh;
       @media (max-width: 768px) {
         padding: 75px 0 75px 0;
+        margin-left: -5px;
       }
       .row {
         @media (max-width: 768px) {
@@ -186,7 +187,7 @@
       max-width: 720px - 240px - 25px;
     }
     @media (max-width: 768px) {
-      padding: 0 0 0 15px;
+      padding: 0 0 0 10px;
       margin-left: -15px;
       max-width: 576px;
     }


### PR DESCRIPTION
More tweaks for mobile.

Changes proposed in this pull request:

- Fixed the squished posters in libraries
- Centered the library entry rating on mobile
- Added more space around modals so they can be closed properly on mobile
- Adjust text in import buttons (looks better on mobile)
- Adjust spacing on browse page to prevent cutoff

/cc @hummingbird-me/staff
