### PR TITLE
Fix library dropdown poster styling

### DIFF
--- a/app/styles/pages/_library.scss
+++ b/app/styles/pages/_library.scss
@@ -319,8 +319,6 @@
   .drop-thumb {
     max-width: 100%;
     border-radius: 3px;
-    width: 40px;
-    height: 40px;
   }
   .drop-title {
     font-size: 18px;

--- a/app/styles/pages/_library.scss
+++ b/app/styles/pages/_library.scss
@@ -318,7 +318,9 @@
   }
   .drop-thumb {
     max-width: 100%;
-    border-radius: 3px;
+    img {
+      border-radius: 3px;
+    }
   }
   .drop-title {
     font-size: 18px;


### PR DESCRIPTION
This reverts a mistake I made with my last commit in #207 (wrong `.drop-thumb`), which appears to have been unnecessary anyways since `.entry-poster` already has fixed dimensions.

Changes proposed in this pull request:

- Reverts changes to library-dropdown poster dimensions
- Fixes the rounded corners on said posters

/cc @hummingbird-me/staff

---
Before|After
---|---
![](https://puu.sh/uFYGJ/26e7f75788.png)|![](https://puu.sh/uFYIk/044b5c35a3.png)
