### PR TITLE
Fix groups style

### DIFF
--- a/app/styles/pages/_groups.scss
+++ b/app/styles/pages/_groups.scss
@@ -1139,6 +1139,10 @@ $primary: #00cc99;
     font-family: "Open Sans",sans-serif;
     font-size: 14px;
     line-height: 25px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-right: 20px;
   }
   .unread-counter {
     position: absolute;

--- a/app/styles/pages/_groups.scss
+++ b/app/styles/pages/_groups.scss
@@ -368,6 +368,9 @@
     position: relative;
     width: 200px;
     float: left;
+    .filter-icon {
+      top: 6px;
+    }
   }
   input {
     background: #fff;
@@ -375,10 +378,9 @@
     border: 0;
     border: 1px solid #e8e8e8;
     box-sizing: border-box;
-    height: 30px;
+    height: 37px;
     padding-left: 32px;
     padding-right: 12px;
-    padding-top: 2px;
     width: 100%;
     font-size: 14px;
     line-height: 18px;

--- a/app/styles/pages/_groups.scss
+++ b/app/styles/pages/_groups.scss
@@ -956,6 +956,9 @@ $primary: #00cc99;
     bottom: 0;
     right: 0;
     padding: 15px;
+    div {
+      padding: 7px 0;
+    }
   }
 
   .message-leaders {
@@ -1003,7 +1006,7 @@ $primary: #00cc99;
 
 .leader-table-wrapper {
   overflow: auto;
-  max-height: 355px;
+  max-height: 300px;
 }
 
 .leader-table {
@@ -1040,7 +1043,7 @@ $primary: #00cc99;
       display: inline-block;
     }
   }
-  tr:last-child {
+  tr:last-of-type {
     th, td {
       border-bottom: none;
     }

--- a/app/styles/pages/_groups.scss
+++ b/app/styles/pages/_groups.scss
@@ -1068,13 +1068,14 @@ $primary: #00cc99;
 
 .group-neighbor-item {
   .media {
-    padding: 5px;
+    padding: 10px;
     align-items: center;
   }
   img {
     width: 60px;
     height: 60px;
     margin-right: 10px;
+    border-radius: 3px;
   }
   .remove-action {
     position: absolute;
@@ -1085,6 +1086,9 @@ $primary: #00cc99;
       width: 16px;
       height: 16px;
     }
+  }
+  .media-body {
+    top: 0;
   }
 }
 


### PR DESCRIPTION
Fixes some styling for the new groups stuff.

Changes proposed in this pull request:

- Adds more spacing around group neighbors and rounds image corners
- [Fix overflow in the group leaders list](https://kitsu.io/feedback/bugs/p/groups-with-more-than-8-leaders-wont-display-them-allor-properly)
- Fix group name overflow in the "My Groups" widget (more noticeable on `/groups`)
- Increases the height of the groups and tickets searchbar to match the sorting dropdown

/cc @hummingbird-me/staff
