### PR TITLE
Add missing manga type translations

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -619,7 +619,7 @@ media-shared:
       manhua: "Manhua"
       oneshot: "One-shot"
       doujin: "Doujin"
-      manwha: "Manhwa"
+      manhwa: "Manhwa"
       oel: "OEL"
 # shared: library
 library-shared:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -619,6 +619,8 @@ media-shared:
       manhua: "Manhua"
       oneshot: "One-shot"
       doujin: "Doujin"
+      manwha: "Manhwa"
+      oel: "OEL"
 # shared: library
 library-shared:
   all: "{type, select,


### PR DESCRIPTION
Fixes missing translations for the manhwa and OEL manga subtypes.
Example: https://kitsu.io/manga/wolf

Also wanted to add that manhwa happens to be spelled incorrectly as ["manwha"](https://github.com/hummingbird-me/hummingbird-server/blob/353816bebdd040de6f7c89b2429ae8e2c0c0146f/app/models/manga.rb#L46) server-side, ~~though I haven't created a PR since I assume it would require a migration to fix existing entries in the db.~~

Changes proposed in this pull request:

- Added translations for manhwa and OEL

/cc @hummingbird-me/staff
