### PR TITLE
Reverse sort mod reports

### DIFF
--- a/app/routes/admin/reports/closed.js
+++ b/app/routes/admin/reports/closed.js
@@ -15,7 +15,8 @@ export default Route.extend(Pagination, {
     return yield this.queryPaginated('report', {
       include: 'user,naughty,moderator',
       filter: { status: '1,2' },
-      page: { offset: 0, limit: 20 }
+      page: { offset: 0, limit: 20 },
+      sort: '-id'
     });
   })
 });

--- a/app/routes/admin/reports/closed.js
+++ b/app/routes/admin/reports/closed.js
@@ -16,7 +16,7 @@ export default Route.extend(Pagination, {
       include: 'user,naughty,moderator',
       filter: { status: '1,2' },
       page: { offset: 0, limit: 20 },
-      sort: '-id'
+      sort: '-updatedAt'
     });
   })
 });

--- a/app/routes/admin/reports/index.js
+++ b/app/routes/admin/reports/index.js
@@ -16,7 +16,7 @@ export default Route.extend(Pagination, {
       include: 'user,naughty,moderator',
       filter: { status: 0 },
       page: { offset: 0, limit: 20 },
-      sort: '-id'
+      sort: '-updatedAt'
     });
   })
 });

--- a/app/routes/admin/reports/index.js
+++ b/app/routes/admin/reports/index.js
@@ -15,7 +15,8 @@ export default Route.extend(Pagination, {
     return yield this.queryPaginated('report', {
       include: 'user,naughty,moderator',
       filter: { status: 0 },
-      page: { offset: 0, limit: 20 }
+      page: { offset: 0, limit: 20 },
+      sort: '-id'
     });
   })
 });


### PR DESCRIPTION
Sorts mod reports from newest to oldest instead of oldest to newest.

Changes proposed in this pull request:

- Reverse sorts mod reports by id

/cc @hummingbird-me/staff
