### PR TITLE
always show tagged media

### DIFF
--- a/app/models/media.js
+++ b/app/models/media.js
@@ -17,6 +17,7 @@ export default Base.extend({
   coverImageTopOffset: attr('number'),
   endDate: attr('utc'),
   favoritesCount: attr('number'),
+  nsfw: attr('boolean'),
   popularityRank: attr('number'),
   posterImage: attr('object', { defaultValue: '/images/default_poster.jpg' }),
   ratingFrequencies: attr('object'),

--- a/app/templates/components/stream-feed/items/post.hbs
+++ b/app/templates/components/stream-feed/items/post.hbs
@@ -142,7 +142,7 @@
       {{/if}}
 
       {{! Tagged Media  }}
-      {{#if (and post.media (or (and post.spoiler (not post.nsfw)) (not isHidden)))}}
+      {{#if post.media}}
         <div class="tagged-media--wrapper">
           <div class="tagged-media row">
             <div class="stream-item--media col-xs-1">

--- a/app/templates/components/stream-feed/items/post.hbs
+++ b/app/templates/components/stream-feed/items/post.hbs
@@ -142,7 +142,7 @@
       {{/if}}
 
       {{! Tagged Media  }}
-      {{#if post.media}}
+      {{#if (and post.media (or (not post.media.nsfw) (not isHidden)))}}
         <div class="tagged-media--wrapper">
           <div class="tagged-media row">
             <div class="stream-item--media col-xs-1">


### PR DESCRIPTION
[feature request](https://kitsu.io/feedback/feature-requests/p/show-animemanga-tag-on-nsfw-post)

I guess these were hidden to hide the posters of nsfw media? Does tagging nsfw media automatically mark the post as nsfw? If not I don't see the reason to hide the tagged media, especially since the user has nsfw on in settings.