### PR TITLE
Sort episodes by season and episode number

### DIFF
--- a/app/routes/media/show/episodes.js
+++ b/app/routes/media/show/episodes.js
@@ -27,9 +27,9 @@ export default Route.extend(Pagination, {
     const options = {
       filter: {
         media_type: capitalize(get(media, 'modelType')),
-        media_id: get(media, 'id'),
-        sort: 'seasonNumber,number'
-      }
+        media_id: get(media, 'id')
+      },
+      sort: 'seasonNumber,number'
     };
     return yield this.queryPaginated('episode', options);
   }),

--- a/app/routes/media/show/episodes.js
+++ b/app/routes/media/show/episodes.js
@@ -27,7 +27,8 @@ export default Route.extend(Pagination, {
     const options = {
       filter: {
         media_type: capitalize(get(media, 'modelType')),
-        media_id: get(media, 'id')
+        media_id: get(media, 'id'),
+        sort: 'seasonNumber,number'
       }
     };
     return yield this.queryPaginated('episode', options);


### PR DESCRIPTION
Episodes appear to be sorted by id by default instead of their number.

Example: https://kitsu.io/anime/monogatari-series-second-season/episodes

Changes proposed in this pull request:

- Sorts episodes on anime pages by season and then by epsiode number

/cc @hummingbird-me/staff
