### PR TITLE
Fix layout of episode images

### DIFF
--- a/app/styles/pages/_media-pages.scss
+++ b/app/styles/pages/_media-pages.scss
@@ -285,7 +285,6 @@
     margin-bottom: 15px;
     img {
       width: 100%;
-      height: 164px;
     }
   }
 }

--- a/app/styles/pages/_media-pages.scss
+++ b/app/styles/pages/_media-pages.scss
@@ -285,6 +285,8 @@
     margin-bottom: 15px;
     img {
       width: 100%;
+      height: 164px;
+      object-fit: cover;
     }
   }
 }

--- a/app/templates/media/show/episodes.hbs
+++ b/app/templates/media/show/episodes.hbs
@@ -23,7 +23,7 @@
     {{! @TODO: Componentsize }}
     <ul class="media--episode-grid row">
       {{#each taskValue as |episode|}}
-        <li class="media--episode-block col-md-4 col-sm-2">
+        <li class="media--episode-block col-lg-4 col-sm-6">
           <div class="thumbnail-wrapper">
             {{lazy-image src=(image episode.thumbnail)}}
           </div>


### PR DESCRIPTION
Fixes https://kitsu.canny.io/bugs/p/multi-window-problems-1

Changes proposed in this pull request:

- ~~Removed the fixed height on episode images~~
- Changed the grid layout of episodes

/cc @hummingbird-me/staff
