### PR TITLE
Add a recently added filter to the browse page

### DIFF
--- a/app/controllers/media/index.js
+++ b/app/controllers/media/index.js
@@ -76,7 +76,7 @@ export const MEDIA_QUERY_PARAMS = {
 };
 
 export default Controller.extend({
-  sortOptions: ['popularity', 'rating', 'date'],
+  sortOptions: ['popularity', 'rating', 'date', 'recent'],
   taskValue: concat('model.taskInstance.value', 'model.paginatedRecords'),
 
   init() {

--- a/app/routes/media/index.js
+++ b/app/routes/media/index.js
@@ -124,6 +124,8 @@ export default Route.extend(SlideHeaderMixin, Pagination, {
         return '-average_rating';
       case 'date':
         return '-start_date';
+      case 'recent':
+        return '-id';
       default:
         return '-user_count';
     }

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -130,6 +130,7 @@ media:
       popularity: "Popularity"
       rating: "Average Rating"
       date: "Date"
+      recent: "Recently Added"
   show:
     navigation:
       summary: "Summary"


### PR DESCRIPTION
I think this should work :crossed_fingers: 

Changes proposed in this pull request:

- add recent filter

/cc @hummingbird-me/staff
