### PR TITLE
Fix feed filter hover

### DIFF
--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -1,4 +1,4 @@
-.feed-aside {
+﻿.feed-aside {
   width: 220px;
   padding-left: 15px;
   @media (max-width: 555px) {
@@ -160,7 +160,7 @@
     background: transparent;
     font-size: 14px;
     &:hover, &:focus {
-      color: $body-link-color;
+      color: $body-link-color !important;
       background: transparent;
     }
   }


### PR DESCRIPTION
Was not applying previously so would go white on hover. Now goes orange!

Previously:
![image](https://user-images.githubusercontent.com/10089976/28583072-beb211a0-715f-11e7-8e8a-c4ad10ae81ef.png)
Now:
![image](https://user-images.githubusercontent.com/10089976/28583044-a11671cc-715f-11e7-841f-5e3a47840223.png)
