### PR TITLE
Notification settings and OneSignal integration

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -16,24 +16,6 @@ export default Controller.extend(queryParams.Mixin, {
   ajax: service(),
   store: service(),
 
-  init() {
-    this._super(...arguments);
-    // create the one-signal-player when user subscribes
-    window.OneSignal.push(() => {
-      window.OneSignal.on('subscriptionChange', (isSubscribed) => {
-        if (isSubscribed && get(this, 'session.isAuthenticated')) {
-          window.OneSignal.getUserId().then((userId) => {
-            get(this, 'store').createRecord('one-signal-player', {
-              playerId: userId,
-              platform: 'web',
-              user: get(this, 'session.account')
-            }).save();
-          });
-        }
-      });
-    });
-  },
-
   queryParamsDidChange({ changed: { notification } }) {
     if (notification && get(this, 'session.hasUser')) {
       this._markNotificationRead(notification).finally(() => {

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -16,6 +16,24 @@ export default Controller.extend(queryParams.Mixin, {
   ajax: service(),
   store: service(),
 
+  init() {
+    this._super(...arguments);
+    // create the one-signal-player when user subscribes
+    window.OneSignal.push(() => {
+      window.OneSignal.on('subscriptionChange', (isSubscribed) => {
+        if (isSubscribed && get(this, 'session.isAuthenticated')) {
+          window.OneSignal.getUserId().then((userId) => {
+            get(this, 'store').createRecord('one-signal-player', {
+              playerId: userId,
+              platform: 'web',
+              user: get(this, 'session.account')
+            }).save();
+          });
+        }
+      });
+    });
+  },
+
   queryParamsDidChange({ changed: { notification } }) {
     if (notification && get(this, 'session.hasUser')) {
       this._markNotificationRead(notification).finally(() => {

--- a/app/controllers/settings/notifications.js
+++ b/app/controllers/settings/notifications.js
@@ -24,7 +24,7 @@ export default Controller.extend({
     });
   }).drop(),
 
-  updateSettingTask: task(function* updateNotificationSetting(setting) {
+  updateSettingTask: task(function* (setting) {
     return yield setting.save().catch((err) => {
       get(this, 'notify').error(errorMessages(err));
       setting.rollbackAttributes();

--- a/app/controllers/settings/notifications.js
+++ b/app/controllers/settings/notifications.js
@@ -1,0 +1,33 @@
+import Controller from 'ember-controller';
+import service from 'ember-service/inject';
+import get from 'ember-metal/get';
+import { alias, filterBy, notEmpty } from 'ember-computed';
+import { isEmpty } from 'ember-utils';
+import { all, task } from 'ember-concurrency';
+import errorMessages from 'client/utils/error-messages';
+
+export default Controller.extend({
+  notify: service(),
+  settings: alias('model.taskInstance.value'),
+  dirtySettings: filterBy('settings', 'hasDirtyAttributes'),
+  isValid: notEmpty('dirtySettings'),
+
+  updateSettingsTask: task(function* () {
+    const settingsTasks = [];
+    get(this, 'dirtySettings').forEach((setting) => {
+      settingsTasks.push(get(this, 'updateSettingTask').perform(setting));
+    });
+    yield all(settingsTasks).then((results) => {
+      if (isEmpty(results.filter(result => result === undefined))) {
+        get(this, 'notify').success('Your notification settings were updated.');
+      }
+    });
+  }).drop(),
+
+  updateSettingTask: task(function* updateNotificationSetting(setting) {
+    return yield setting.save().catch((err) => {
+      get(this, 'notify').error(errorMessages(err));
+      setting.rollbackAttributes();
+    });
+  })
+});

--- a/app/initializers/browser-scripts.js
+++ b/app/initializers/browser-scripts.js
@@ -57,7 +57,15 @@ function onesignal() {
     autoRegister: false,
     notifyButton: { enable: false },
     persistNotification: false,
-    welcomeNotification: { title: 'Kitsu' }
+    welcomeNotification: { title: 'Kitsu' },
+    promptOptions: {
+      // actionMessage limited to 90 characters
+      actionMessage: 'Enable notifications to stay updated on all the new activity.',
+      // acceptButtonText limited to 15 characters
+      acceptButtonText: 'SURE!',
+      // cancelButtonText limited to 15 characters
+      cancelButtonText: 'NO THANKS'
+    }
   }]);
   injectScript('https://cdn.onesignal.com/sdks/OneSignalSDK.js').catch(() => {});
 }

--- a/app/initializers/browser-scripts.js
+++ b/app/initializers/browser-scripts.js
@@ -46,6 +46,22 @@ function embedly() {
   injectScript('https://cdn.embedly.com/widgets/platform.js').catch(() => {});
 }
 
+/**
+ * Inject OneSignal's script into the `head` on initialzation.
+ */
+function onesignal() {
+  window.OneSignal = window.OneSignal || [];
+  window.OneSignal.push(['init', {
+    appId: config.onesignal.appId,
+    allowLocalhostAsSecureOrigin: true,
+    autoRegister: false,
+    notifyButton: { enable: false },
+    persistNotification: false,
+    welcomeNotification: { title: 'Kitsu' }
+  }]);
+  injectScript('https://cdn.onesignal.com/sdks/OneSignalSDK.js').catch(() => {});
+}
+
 export function initialize() {
   // Don't bother if we don't have DOM access, FastBoot?
   if (!canUseDOM) { return; }
@@ -61,6 +77,7 @@ export function initialize() {
   adwords();
   canny();
   embedly();
+  onesignal();
 }
 
 export default {

--- a/app/initializers/browser-scripts.js
+++ b/app/initializers/browser-scripts.js
@@ -52,7 +52,7 @@ function embedly() {
 function onesignal() {
   window.OneSignal = window.OneSignal || [];
   window.OneSignal.push(['init', {
-    appId: config.onesignal.appId,
+    appId: config.onesignal[config.kitsu.env].appId,
     allowLocalhostAsSecureOrigin: true,
     autoRegister: false,
     notifyButton: { enable: false },

--- a/app/models/notification-setting.js
+++ b/app/models/notification-setting.js
@@ -1,0 +1,12 @@
+import Base from 'client/models/-base';
+import attr from 'ember-data/attr';
+import { belongsTo } from 'ember-data/relationships';
+
+export default Base.extend({
+  settingType: attr('string'),
+  emailEnabled: attr('boolean'),
+  mobileEnabled: attr('boolean'),
+  webEnabled: attr('boolean'),
+
+  user: belongsTo('user', { inverse: 'notificationSettings' })
+});

--- a/app/models/one-signal-player.js
+++ b/app/models/one-signal-player.js
@@ -1,0 +1,10 @@
+import Base from 'client/models/-base';
+import attr from 'ember-data/attr';
+import { belongsTo } from 'ember-data/relationships';
+
+export default Base.extend({
+  playerId: attr('string'),
+  platform: attr('string'),
+
+  user: belongsTo('user')
+});

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -88,6 +88,7 @@ export default Base.extend(Validations, {
   favorites: hasMany('favorite', { inverse: 'user' }),
   followers: hasMany('follow', { inverse: 'followed' }),
   following: hasMany('follow', { inverse: 'follower' }),
+  notificationSettings: hasMany('notification-setting', { inverse: 'user' }),
   profileLinks: hasMany('profile-link', { inverse: 'user' }),
   userRoles: hasMany('user-role'),
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -89,6 +89,7 @@ export default Base.extend(Validations, {
   followers: hasMany('follow', { inverse: 'followed' }),
   following: hasMany('follow', { inverse: 'follower' }),
   notificationSettings: hasMany('notification-setting', { inverse: 'user' }),
+  oneSignalPlayers: hasMany('one-signal-player', { inverse: 'user' }),
   profileLinks: hasMany('profile-link', { inverse: 'user' }),
   userRoles: hasMany('user-role'),
 

--- a/app/router.js
+++ b/app/router.js
@@ -105,6 +105,7 @@ RouterInstance.map(function() {
 
   this.route('settings', function() {
     this.route('index', { path: '/profile' });
+    this.route('notifications');
     this.route('password');
     this.route('privacy');
     this.route('linked-accounts');

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -128,6 +128,12 @@ export default Route.extend(ApplicationRouteMixin, {
       this._loadTheme(user);
       get(this, 'moment').changeTimeZone(get(user, 'timeZone') || moment.tz.guess());
 
+      // notifications
+      window.OneSignal.push(() => {
+        // TODO: register with slidedown on authed page load, with new step in onboarding
+        window.OneSignal.registerForPushNotifications();
+      });
+
       // metrics
       get(this, 'metrics').identify({
         distinctId: get(user, 'id'),

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -150,7 +150,9 @@ export default Route.extend(ApplicationRouteMixin, {
 
   _registerNotifications() {
     window.OneSignal.push(() => {
-      window.OneSignal.registerForPushNotifications();
+      if (get(this, 'session.isAuthenticated') && get(this, 'session.account.feedCompleted')) {
+        window.OneSignal.showHttpPrompt();
+      }
 
       // create the one-signal-player when user subscribes
       window.OneSignal.on('subscriptionChange', (isSubscribed) => {

--- a/app/routes/settings/notifications.js
+++ b/app/routes/settings/notifications.js
@@ -1,0 +1,15 @@
+import Route from 'ember-route';
+import get from 'ember-metal/get';
+import { task } from 'ember-concurrency';
+
+export default Route.extend({
+  model() {
+    return { taskInstance: get(this, 'getNotificationSettingsTask').perform() };
+  },
+
+  getNotificationSettingsTask: task(function* () {
+    return yield get(this, 'store').query('notification-setting', {
+      filter: { userId: get(this, 'session.account.id') }
+    });
+  }).drop()
+});

--- a/app/styles/pages/_settings.scss
+++ b/app/styles/pages/_settings.scss
@@ -126,6 +126,10 @@
 
 }
 
+.notification-settings-container {
+  max-width: 800px;
+}
+
 .notification-settings--table {
   list-style-type: none;
   margin: 0;
@@ -133,7 +137,15 @@
   width: 100%;
 }
 
+.notification-settings--right {
+  width: 25%;
+  display: flex;
+  justify-content: space-around;
+}
+
 .notification-settings--headers {
+  display: flex;
+  justify-content: flex-end;
   margin-top: -20px;
   background: #eee;
   font-size: 12px;
@@ -156,6 +168,8 @@
   }
 }
 .notification-settings--item {
+  display: flex;
+  justify-content: space-between;
   border-bottom: 1px solid $divider-color;
   margin-bottom: 15px;
   padding-bottom: 10px;
@@ -166,8 +180,14 @@
 
 .settings-column {
   display: inline-block;
-  &.checkbox-wrapper {
-    text-align: center;
+}
+
+.notification-settings-button {
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+  button {
+    min-width: 300px;
   }
 }
 

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -9,6 +9,9 @@
         {{#link-to "settings.index" tagName="li" class="list-item"}}
           <a href={{href-to "settings.index"}}>Profile</a>
         {{/link-to}}
+        {{#link-to "settings.notifications" tagName="li" class="list-item"}}
+          <a href={{href-to "settings.notifications"}}>Notifications</a>
+        {{/link-to}}
         {{#link-to "settings.password" tagName="li" class="list-item"}}
           <a href={{href-to "settings.password"}}>Password</a>
         {{/link-to}}

--- a/app/templates/settings/notifications.hbs
+++ b/app/templates/settings/notifications.hbs
@@ -1,110 +1,76 @@
-<div class="settings-container">
-  <h1>Notifications</h1>
+<div class="notification-settings-container settings-container">
+  <h1>{{t "settings.notifications.header"}}</h1>
 
   <div class="settings--section-head">
-    General site-wide notifications
+    {{t "settings.notifications.sub-header"}}
   </div>
   <div class="container">
-    <div class="row">
-      <ul class="notification-settings--table">
-        <li class="notification-settings--headers">
-          <div class="settings-column col-xs-5"></div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            Site
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            Email
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            Push
-          </div>
-        </li>
-        <li class="notification-settings--item">
-          <label class="settings-column col-xs-5">Post Likes</label>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
+    {{#if model.taskInstance.isRunning}}
+      <div class="text-xs-center w-100 m-t-1 m-b-1">
+        {{loading-spinner size="large"}}
+        <p>{{t "settings.notifications.loading"}}</p>
+      </div>
+    {{else if model.taskInstance.error}}
+      <div class="text-xs-center w-100 m-t-1 m-b-1">
+        {{t "errors.load"}}
+      </div>
+    {{else if settings}}
+      <div class="row">
+        <ul class="notification-settings--table">
+          <li class="notification-settings--headers">
+            <div class="notification-settings--right">
+              <div class="settings-column">
+                {{t "settings.notifications.contexts.web"}}
+              </div>
+              <div class="settings-column">
+                {{t "settings.notifications.contexts.email"}}
+              </div>
+              <div class="settings-column">
+                {{t "settings.notifications.contexts.mobile"}}
+              </div>
             </div>
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-        </li>
-        <li class="notification-settings--item">
-          <label class="settings-column col-xs-5">Post Replies</label>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-        </li>
-        <li class="notification-settings--item">
-          <label class="settings-column col-xs-5">Mentions</label>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-        </li>
-        <li class="notification-settings--item">
-          <label class="settings-column col-xs-5">New Follows</label>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-          <div class="settings-column checkbox-wrapper col-xs-2">
-            <div>
-              <input type="checkbox">
-              <label class="checkbox-label"></label>
-            </div>
-          </div>
-        </li>
-
-      </ul>
-    </div>
+          </li>
+          {{#each settings as |setting|}}
+            <li class="notification-settings--item">
+              <label class="settings-column">
+                {{t (concat "settings.notifications.descriptions." setting.settingType) htmlSafe=true}}
+              </label>
+              <div class="notification-settings--right">
+                <div class="settings-column">
+                  <label class="checkbox-label">
+                    {{one-way-checkbox setting.webEnabled
+                      update=(action (mut setting.webEnabled))
+                    }}
+                  </label>
+                </div>
+                <div class="settings-column">
+                  <label class="checkbox-label">
+                    {{one-way-checkbox setting.emailEnabled
+                      update=(action (mut setting.emailEnabled))
+                    }}
+                  </label>
+                </div>
+                <div class="settings-column">
+                  <label class="checkbox-label">
+                    {{one-way-checkbox setting.mobileEnabled
+                      update=(action (mut setting.mobileEnabled))
+                    }}
+                  </label>
+                </div>
+              </div>
+            </li>
+          {{/each}}
+        </ul>
+      </div>
+      <div class="notification-settings-button">
+        <button class="button button--primary btn-lg notification-settings-button" disabled={{unless isValid "disabled"}} onclick={{perform updateSettingsTask}}>
+          {{#if updateSettingsTask.isRunning}}
+            {{loading-spinner size="small"}}
+          {{else}}
+            {{t "settings.notifications.update"}}
+          {{/if}}
+        </button>
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -135,6 +135,11 @@ module.exports = function(environment) {
 
     embedly: {
       apiKey: '90f3fb8ff40f4603991aa258127ccb5e'
+    },
+
+    onesignal: {
+      // TODO: Change this to a real app id
+      appId: '4bd004d1-31c1-4f36-8c21-de2e4415ce76'
     }
   };
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -138,8 +138,15 @@ module.exports = function(environment) {
     },
 
     onesignal: {
-      // TODO: Change this to a real app id
-      appId: '4bd004d1-31c1-4f36-8c21-de2e4415ce76'
+      production: {
+        appId: '01f6e47a-6809-4118-a796-949952e9c209'
+      },
+      staging: {
+        appId: '9933b0ac-ca94-4990-931b-7efa6bafdfd6'
+      },
+      development: {
+        appId: '9933b0ac-ca94-4990-931b-7efa6bafdfd6'
+      }
     }
   };
 

--- a/config/manifest.js
+++ b/config/manifest.js
@@ -4,6 +4,7 @@ module.exports = function() {
     short_name: 'Kitsu',
     start_url: '/?utm_source=web_app_manifest',
     display: 'standalone',
+    gcm_sender_id: '482941778795',
     orientation: 'portrait',
     background_color: '#332532',
     theme_color: '#332532',

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -49,9 +49,12 @@ module.exports = function(defaults) {
       }
     },
 
-    // can be removed when ember-web-app supports mstile
     fingerprint: {
       exclude: [
+        'OneSignalSDKWorker.js',
+        'OneSignalSDKUpdaterWorker.js',
+
+        // can be removed when ember-web-app supports mstile
         'mstile-70x70.png',
         'mstile-150x150.png',
         'mstile-310x150.png',

--- a/public/OneSignalSDKUpdaterWorker.js
+++ b/public/OneSignalSDKUpdaterWorker.js
@@ -1,0 +1,1 @@
+importScripts('https://cdn.onesignal.com/sdks/OneSignalSDK.js');

--- a/public/OneSignalSDKWorker.js
+++ b/public/OneSignalSDKWorker.js
@@ -1,0 +1,1 @@
+importScripts('https://cdn.onesignal.com/sdks/OneSignalSDK.js');

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -638,6 +638,21 @@ settings:
         pending: "Pending"
         success: "Success"
         error: "Error"
+  notifications:
+    header: "Notifications"
+    sub-header: "General site-wide notifications"
+    contexts:
+      web: "Web"
+      email: "Email"
+      mobile: "Mobile"
+    descriptions:
+      mentions: "Someone <strong>mentions</strong> me in a post or comment"
+      replies: "Someone <strong>replies</strong> to my post or comment"
+      likes: "Someone <strong>likes</strong> my post or comment"
+      follows: "Someone <strong>follows</strong> me"
+      posts: "Someone <strong>posts</strong> on my profile"
+    loading: "Loading settings..."
+    update: "Update Settings"
 # page: feedback
 feedback:
   bugs: "Bugs"


### PR DESCRIPTION
todo:
- [x] merge https://github.com/hummingbird-me/hummingbird-server/pull/200
- [x] set app id in env
- [x] complete steps [1 and 4](https://documentation.onesignal.com/docs/web-push-sdk-setup-https) to configure OneSignal
- [x] enable slideover
- [x] prompt after finishing feed onboarding 
- [x] customize messages
- [x] retries for player creation

things to consider:
- Once a user has disabled notifications after subscribing, there is apparently no way to resubscribe until they clear site data, even if they change permissions to allow them again. OneSignal treats the user as having blocked notifications, and doesn't attempt to resubscribe.
- We have the option of displaying a slidedown popup with a custom message before triggering the permission modal. The only problem with this is it will show if the user has blocked and reallowed notifications, so clicking confirm on the slidedown will actually fail to trigger the permission modal for the reason stated in the first bullet point.
- How do we handle a failed OneSignal player creation after enabling the permission?
- We might want to have another step in onboarding with a message about notifications and a button to trigger the permission modal.