### PR TITLE
Fix media activity feed regression

### DIFF
--- a/app/components/stream-feed/items/library-entry.js
+++ b/app/components/stream-feed/items/library-entry.js
@@ -12,7 +12,7 @@ export default Component.extend({
   isSynopsisExpanded: false,
   hasMoreActivities: false,
   showAll: false,
-  activityLimit: 3,
+  activityLimit: 2,
   metrics: service(),
 
   media: getter(function() {


### PR DESCRIPTION
677f829 was not fully checked to see what it effects 😉 

The `display: none` removed was for the list in the feed, which then displays all 3

![](https://i.imgur.com/R1r6RlJ.png)

![](https://i.imgur.com/waYqVlf.png)

Although it being given 3, with 1 hidden in the first place is wrong - as only 2 are ever needed (and the way it was currently implemented hid the 3rd item in the full `view more` list)