### PR TITLE
Fix media reaction avatar position

### DIFF
--- a/app/styles/components/_user-card.scss
+++ b/app/styles/components/_user-card.scss
@@ -32,7 +32,7 @@
     .card-img-avatar {
       position: relative;
       margin-top: -70px;
-      margin-left: -225px;
+      margin-left: -165px;
       width: 100px;
       height: 100px;
     }


### PR DESCRIPTION
User avatars were stuck between the reaction and the user card.

Changes proposed in this pull request:

- changed the margin of avatars on the media reaction page

/cc @hummingbird-me/staff
