### PR TITLE
Fix alignment of group actions

### DIFF
--- a/app/styles/pages/_groups.scss
+++ b/app/styles/pages/_groups.scss
@@ -366,6 +366,9 @@
       position: absolute;
       top: 20px;
       right: 30px;
+      .stream-item-options {
+        margin-right: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
Group actions were not properly right-aligned.

Changes proposed in this pull request:

- remove the margin on group actions

/cc @hummingbird-me/staff
