### PR TITLE
Aozora Reonboarding

### DIFF
--- a/app/components/application/auth-onboarding/aozora-account-details.js
+++ b/app/components/application/auth-onboarding/aozora-account-details.js
@@ -1,31 +1,14 @@
-import Component from '@ember/component';
-import { inject as service } from '@ember/service';
-import { get, set, computed } from '@ember/object';
+import SignUp from 'client/components/application/auth-onboarding/sign-up';
+import { get, set } from '@ember/object';
 import { task } from 'ember-concurrency';
-import { and, alias } from '@ember/object/computed';
+import { alias } from '@ember/object/computed';
 import errorMessages from 'client/utils/error-messages';
 import { invokeAction } from 'ember-invoke-action';
-import strength from 'password-strength';
 
-export default Component.extend({
-  metrics: service(),
-  notify: service(),
-  store: service(),
-  tracking: service(),
-
+export default SignUp.extend({
   user: alias('session.account'),
 
-  hasValidName: and('user.name', 'user.validations.attrs.name.isValid'),
-  hasValidEmail: and('user.email', 'user.validations.attrs.email.isValid'),
-  hasValidPassword: and('user.password', 'user.validations.attrs.password.isValid'),
-
-  hasInvalidName: and('user.name', 'user.validations.attrs.name.isInvalid'),
-  hasInvalidEmail: and('user.email', 'user.validations.attrs.email.isInvalid'),
-  hasInvalidPassword: and('user.password', 'user.validations.attrs.password.isInvalid'),
-
-  passwordStrength: computed('user.password', function() {
-    return strength(get(this, 'user.password') || '');
-  }),
+  _setupUser() {},
 
   updateAccount: task(function* () {
     set(this, 'user.status', 'registered');
@@ -35,14 +18,5 @@ export default Component.extend({
       get(this, 'notify').error(errorMessages(err));
     }
     invokeAction(this, 'close');
-  }).drop(),
-
-  actions: {
-    focused(event) {
-      const target = this.$('.auth-section').has(event.target);
-      if (target.hasClass('active') === false) {
-        target.addClass('active');
-      }
-    }
-  }
+  }).drop()
 });

--- a/app/components/application/auth-onboarding/aozora-account-details.js
+++ b/app/components/application/auth-onboarding/aozora-account-details.js
@@ -1,9 +1,8 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
-import { get, set, getProperties, setProperties, computed } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { task } from 'ember-concurrency';
 import { and, alias } from '@ember/object/computed';
-import { isPresent } from '@ember/utils';
 import errorMessages from 'client/utils/error-messages';
 import { invokeAction } from 'ember-invoke-action';
 import strength from 'password-strength';

--- a/app/components/application/auth-onboarding/aozora-account-details.js
+++ b/app/components/application/auth-onboarding/aozora-account-details.js
@@ -1,0 +1,49 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { get, set, getProperties, setProperties, computed } from '@ember/object';
+import { task } from 'ember-concurrency';
+import { and, alias } from '@ember/object/computed';
+import { isPresent } from '@ember/utils';
+import errorMessages from 'client/utils/error-messages';
+import { invokeAction } from 'ember-invoke-action';
+import strength from 'password-strength';
+
+export default Component.extend({
+  metrics: service(),
+  notify: service(),
+  store: service(),
+  tracking: service(),
+
+  user: alias('session.account'),
+
+  hasValidName: and('user.name', 'user.validations.attrs.name.isValid'),
+  hasValidEmail: and('user.email', 'user.validations.attrs.email.isValid'),
+  hasValidPassword: and('user.password', 'user.validations.attrs.password.isValid'),
+
+  hasInvalidName: and('user.name', 'user.validations.attrs.name.isInvalid'),
+  hasInvalidEmail: and('user.email', 'user.validations.attrs.email.isInvalid'),
+  hasInvalidPassword: and('user.password', 'user.validations.attrs.password.isInvalid'),
+
+  passwordStrength: computed('user.password', function() {
+    return strength(get(this, 'user.password') || '');
+  }),
+
+  updateAccount: task(function* () {
+    set(this, 'user.status', 'registered');
+    try {
+      yield get(this, 'user').save();
+    } catch (err) {
+      get(this, 'notify').error(errorMessages(err));
+    }
+    invokeAction(this, 'close');
+  }).drop(),
+
+  actions: {
+    focused(event) {
+      const target = this.$('.auth-section').has(event.target);
+      if (target.hasClass('active') === false) {
+        target.addClass('active');
+      }
+    }
+  }
+});

--- a/app/components/application/auth-onboarding/aozora-conflict.js
+++ b/app/components/application/auth-onboarding/aozora-conflict.js
@@ -9,10 +9,15 @@ export default Component.extend({
   conflicts: {},
   chosen: '',
 
+  init() {
+    this._super(...arguments);
+    get(this, 'getConflicts').perform();
+  },
+
   getConflicts: task(function* () {
     const conflicts = yield get(this, 'aozoraConflicts').list();
     set(this, 'conflicts', conflicts);
-  }).on('init'),
+  }),
 
   choose: task(function* (chosen) {
     set(this, 'chosen', chosen);

--- a/app/components/application/auth-onboarding/aozora-conflict.js
+++ b/app/components/application/auth-onboarding/aozora-conflict.js
@@ -10,7 +10,7 @@ export default Component.extend({
   chosen: '',
 
   getConflicts: task(function* () {
-    let conflicts = yield get(this, 'aozoraConflicts').list();
+    const conflicts = yield get(this, 'aozoraConflicts').list();
     set(this, 'conflicts', conflicts);
   }).on('init'),
 

--- a/app/components/application/auth-onboarding/aozora-conflict.js
+++ b/app/components/application/auth-onboarding/aozora-conflict.js
@@ -1,0 +1,22 @@
+import Component from '@ember/component';
+import { get, set } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { invokeAction } from 'ember-invoke-action';
+import { task } from 'ember-concurrency';
+
+export default Component.extend({
+  aozoraConflicts: service(),
+  conflicts: {},
+  chosen: '',
+
+  getConflicts: task(function* () {
+    let conflicts = yield get(this, 'aozoraConflicts').list();
+    set(this, 'conflicts', conflicts);
+  }).on('init'),
+
+  choose: task(function* (chosen) {
+    set(this, 'chosen', chosen);
+    yield get(this, 'aozoraConflicts').resolve(chosen);
+    invokeAction(this, 'changeComponent', 'aozora-account-details');
+  }).drop()
+});

--- a/app/components/application/auth-onboarding/sign-in.js
+++ b/app/components/application/auth-onboarding/sign-in.js
@@ -28,7 +28,7 @@ export default Component.extend({
 
   loginWithFacebook: task(function* () {
     try {
-      yield get(this, 'session').authenticateWithFacebook()
+      yield get(this, 'session').authenticateWithFacebook();
       yield get(this, 'gotoNext').perform();
     } catch (error) {
       // Facebook succeeded but Kitsu failed (no-account)

--- a/app/components/application/auth-onboarding/sign-in.js
+++ b/app/components/application/auth-onboarding/sign-in.js
@@ -46,7 +46,7 @@ export default Component.extend({
 
   gotoNext: task(function* () {
     const user = yield get(this, 'session').getCurrentUser();
-    if (user) {
+    if (get(user, 'isAozoraImported')) {
       const conflicts = yield get(this, 'aozoraConflicts').list();
       if (conflicts.length > 1) {
         invokeAction(this, 'changeComponent', 'aozora-conflict');

--- a/app/components/application/auth-onboarding/sign-in.js
+++ b/app/components/application/auth-onboarding/sign-in.js
@@ -20,7 +20,7 @@ export default Component.extend({
     const { identification, password } = getProperties(this, 'identification', 'password');
     try {
       yield get(this, 'session').authenticateWithOAuth2(identification, password);
-      yield gotoNext.perform();
+      yield get(this, 'gotoNext').perform();
     } catch (err) {
       get(this, 'notify').error(errorMessages(err));
     }
@@ -29,7 +29,7 @@ export default Component.extend({
   loginWithFacebook: task(function* () {
     try {
       yield get(this, 'session').authenticateWithFacebook()
-      yield gotoNext.perform();
+      yield get(this, 'gotoNext').perform();
     } catch (error) {
       // Facebook succeeded but Kitsu failed (no-account)
       if (error.error === 'invalid_grant') {

--- a/app/components/application/auth-onboarding/sign-up.js
+++ b/app/components/application/auth-onboarding/sign-up.js
@@ -43,6 +43,10 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+    this._setupUser();
+  },
+
+  _setupUser() {
     const user = get(this, 'store').createRecord('user');
     set(this, 'user', user);
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -2,7 +2,7 @@ import Base from 'client/models/-base';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 import { validator, buildValidations } from 'ember-cp-validations';
-import { alias } from '@ember/object/computed';
+import { alias, empty } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import { classify } from '@ember/string';
 import { get, computed } from '@ember/object';
@@ -32,10 +32,17 @@ export const Validations = buildValidations({
     })
   ],
   password: {
-    disabled: alias('model.hasPassword'),
     validators: [
-      validator('presence', true),
-      validator('length', { min: 8 })
+      validator('presence', {
+        // Disable if this user already has a password
+        disabled: alias('model.hasPassword'),
+        presence: true
+      }),
+      validator('length', {
+        // Disable if the password is empty
+        disabled: empty('model.password'),
+        min: 8
+      })
     ]
   }
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -2,6 +2,7 @@ import Base from 'client/models/-base';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 import { validator, buildValidations } from 'ember-cp-validations';
+import { alias } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import { classify } from '@ember/string';
 import { get, computed } from '@ember/object';
@@ -30,10 +31,13 @@ export const Validations = buildValidations({
       messageKey: 'errors.user.name.starts'
     })
   ],
-  password: [
-    validator('presence', true),
-    validator('length', { min: 8 })
-  ]
+  password: {
+    disabled: alias('model.hasPassword'),
+    validators: [
+      validator('presence', true),
+      validator('length', { min: 8 })
+    ]
+  }
 });
 
 export default Base.extend(Validations, {
@@ -52,6 +56,7 @@ export default Base.extend(Validations, {
   followersCount: attr('number'),
   followingCount: attr('number'),
   gender: attr('string'),
+  hasPassword: attr('boolean'),
   language: attr('string'),
   likesGivenCount: attr('number'),
   location: attr('string'),

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -69,6 +69,7 @@ export default Base.extend(Validations, {
   sfwFilter: attr('boolean'),
   slug: attr('string'),
   shareToGlobal: attr('boolean'),
+  status: attr('string', { defaultValue: 'registered' }),
   timeZone: attr('string'),
   title: attr('string'),
   titleLanguagePreference: attr('string', { defaultValue: 'canonical' }),
@@ -103,6 +104,10 @@ export default Base.extend(Validations, {
       return false;
     }
     return !date.isBefore();
+  }).readOnly(),
+
+  isAozoraImported: computed('status', function() {
+    return get(this, 'status') === 'aozora';
   }).readOnly(),
 
   isSimpleRating: computed('ratingSystem', function() {

--- a/app/services/aozora-conflicts.js
+++ b/app/services/aozora-conflicts.js
@@ -1,0 +1,20 @@
+import Service, { inject as service } from '@ember/service';
+import { get, set } from '@ember/object';
+
+export default Service.extend({
+  ajax: service(),
+
+  list(user) {
+    return get(this, 'ajax').request('/users/_conflicts', {
+      method: 'GET'
+    });
+  },
+
+  resolve(chosen) {
+    return get(this, 'ajax').request('/users/_conflicts', {
+      method: 'POST',
+      dataType: 'json',
+      data: { chosen }
+    });
+  }
+});

--- a/app/services/aozora-conflicts.js
+++ b/app/services/aozora-conflicts.js
@@ -1,10 +1,10 @@
 import Service, { inject as service } from '@ember/service';
-import { get, set } from '@ember/object';
+import { get } from '@ember/object';
 
 export default Service.extend({
   ajax: service(),
 
-  list(user) {
+  list() {
     return get(this, 'ajax').request('/users/_conflicts', {
       method: 'GET'
     });

--- a/app/templates/components/application/auth-onboarding/aozora-account-details.hbs
+++ b/app/templates/components/application/auth-onboarding/aozora-account-details.hbs
@@ -1,0 +1,74 @@
+<div class="modal-wrapper">
+  <form>
+    <div class="auth-section">
+      <h6 class="auth-section-title">What email should we use?</h6>
+      <p class="auth-section-helper">We'll use your email address to send you occasional updates and help you out if you forget your password.</p>
+      <div class="form-group {{if hasInvalidEmail "has-warning"}} {{if hasValidEmail "has-success"}}">
+        {{one-way-email user.email
+          update=(action (mut user.email))
+          class=(form-input-class hasInvalidEmail hasValidEmail)
+          focusIn=(action "focused")
+          placeholder="Email"
+          data-test-email="true"}}
+        {{#if hasInvalidEmail}}
+          <div class="form-control-feedback" data-test-validation-email>
+            {{v-get user "email" "message"}}
+          </div>
+        {{/if}}
+      </div>
+    </div>
+
+    <div class="auth-section {{if hasValidName "active"}}">
+      <h6 class="auth-section-title">What should we call you?</h6>
+      <p class="auth-section-helper">Your username should be original, being witty is optional.</p>
+      <div class="form-group {{if hasInvalidName "has-warning"}} {{if hasValidName "has-success"}}">
+        {{one-way-text user.name
+          update=(action (mut user.name))
+          class=(form-input-class hasInvalidName hasValidName)
+          focusIn=(action "focused")
+          placeholder="Username"
+          autofocus="autofocus"
+          data-test-username="true"}}
+        {{#if hasInvalidName}}
+          <div class="form-control-feedback" data-test-validation-username>
+            {{v-get user "name" "message"}}
+          </div>
+        {{/if}}
+      </div>
+    </div>
+
+    {{#unless user.hasPassword}}
+      <div class="auth-section">
+        <h6 class="auth-section-title">Think of a strong password.</h6>
+        <p class="auth-section-helper">Your password should be at least 8 characters. You should also consider mixing in numbers and special characters! This is to keep the bad guys from doing bad guy things with your account.</p>
+        <div class="form-group password-form {{if hasInvalidPassword "has-warning"}} {{if hasValidPassword "has-success"}}">
+          {{one-way-password user.password
+            update=(action (mut user.password))
+            class=(form-input-class hasInvalidPassword hasValidPassword)
+            focusIn=(action "focused")
+            placeholder="Password"
+            data-test-password="true"}}
+          {{#if hasInvalidPassword}}
+            <div class="form-control-feedback" data-test-validation-password>
+              {{v-get user "password" "message"}}
+            </div>
+          {{/if}}
+          <span class="password-step password-{{passwordStrength.score}}" data-test-password-strength>
+          </span>
+        </div>
+      </div>
+    {{/unless}}
+
+    <div class="form-group form-cta">
+      <button type="submit" class="button button--primary"
+              disabled={{if user.validations.isInvalid "disabled"}}
+              {{action (perform updateAccount)}}>
+        {{#if updateAccount.isRunning}}
+          {{loading-spinner}}
+        {{else}}
+          {{t "onboarding.sign-up.submit" step=step}}
+        {{/if}}
+      </button>
+    </div>
+  </form>
+</div>

--- a/app/templates/components/application/auth-onboarding/aozora-conflict.hbs
+++ b/app/templates/components/application/auth-onboarding/aozora-conflict.hbs
@@ -1,0 +1,20 @@
+<div class="modal-wrapper">
+  <div class="auth-section active">
+    <h6 class="auth-section-title">{{t "onboarding.aozora.conflict.title"}}</h6>
+    <p class="auth-section-helper">{{t "onboarding.aozora.conflict.info"}}</p>
+    {{#if getConflicts.isRunning}}
+      {{loading-spinner}}
+    {{else}}
+      {{#each-in conflicts as |site account|}}
+        <a href="#" class="import-option" onclick={{perform choose site}}>
+          <span class="import-logo">
+            <img src="/images/{{site}}.png">
+          </span>
+          <span class="import-title">
+            {{account.name}} ({{account.library_entries}} in library)
+          </span>
+        </a>
+      {{/each-in}}
+    {{/if}}
+  </div>
+</div>

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -990,6 +990,12 @@ form-shared:
   placeholders:
     username: "Username"
     password: "Password"
+# component: auth-onboarding
+onboarding:
+  aozora:
+    conflict:
+      title: "Oh, you already have a Kitsu account! Which do you want to keep?"
+      info: "Activity feed posts from both accounts will be merged.  All other account information will be overwritten by the account you select below."
 # component: follow-button
 follow-button:
   follow: "Follow"


### PR DESCRIPTION
Basic reonboarding process for Aozora, nothing fancy and the markup is TRASH, but pretty can come after this goes through QA

After login, if the user has a `status=aozora` we send them through two steps before they get modified to `status=registered`:

1. Resolve Conflict between Kitsu & Aozora accounts (if there is one)
2. Make sure your account info is right (and possibly set a password)