### PR TITLE
Update User validations for slug-name split

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -6,7 +6,6 @@ import { alias, empty, or } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import { classify } from '@ember/string';
 import { get, computed } from '@ember/object';
-import { empty } from '@ember/object/computed';
 
 export const Validations = buildValidations({
   email: [

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -6,6 +6,7 @@ import { alias, empty, or } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import { classify } from '@ember/string';
 import { get, computed } from '@ember/object';
+import { empty } from '@ember/object/computed';
 
 export const Validations = buildValidations({
   email: [
@@ -17,20 +18,26 @@ export const Validations = buildValidations({
   ],
   name: [
     validator('presence', true),
-    validator('length', { min: 3, max: 20 }),
-    validator('format', {
-      regex: /^[_a-zA-Z0-9]+$/,
-      messageKey: 'errors.user.name.invalid'
-    }),
-    validator('format', {
-      regex: /(?!^\d+$)^.+$/,
-      messageKey: 'errors.user.name.numbers'
-    }),
-    validator('format', {
-      regex: /^[a-zA-Z0-9]/,
-      messageKey: 'errors.user.name.starts'
-    })
+    validator('length', { min: 3, max: 20 })
   ],
+  slug: {
+    disabled: empty('model.slug'),
+    validators: [
+      validator('length', { min: 3, max: 20 }),
+      validator('format', {
+        regex: /^[_a-zA-Z0-9]+$/,
+        messageKey: 'errors.user.name.invalid'
+      }),
+      validator('format', {
+        regex: /(?!^\d+$)^.+$/,
+        messageKey: 'errors.user.name.numbers'
+      }),
+      validator('format', {
+        regex: /^[a-zA-Z0-9]/,
+        messageKey: 'errors.user.name.starts'
+      })
+    ]
+  },
   password: {
     validators: [
       validator('presence', {

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -66,7 +66,7 @@ test('shows validation warnings on input fields', function(assert) {
   click('[data-test-sign-up-header]');
   click('[data-test-sign-up-email]');
 
-  fillIn('[data-test-username]', '1234');
+  fillIn('[data-test-username]', 'ab');
   andThen(() => {
     const error = find('[data-test-validation-username]');
     assert.equal(error.length, 1);

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -31,13 +31,15 @@ moduleForModel('user', 'Unit | Model | user', {
 test('model validations', function(assert) {
   const user = this.subject();
   const valid = {
-    name: ['Okabe', '123Okabe'],
+    name: ['Okabe', '123 Okabe', 'Josh is a 💩', '岡部 倫太郎', 'Okabe Rintarō'],
+    slug: ['Okabe', '123Okabe', null, undefined],
     email: ['a@b.com', 'email+ignore@host.tld'],
     password: ['password']
   };
 
   const invalid = {
-    name: ['ab', '12345', '_okabe', 'asdadasdasdasdasdadadasd', '', null, undefined],
+    name: ['ab', 'abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde', null, undefined],
+    slug: ['ab', '12345', '_okabe', 'asdadasdasdasdasdadadasd'],
     email: ['abc', 'abc@a', 'abc@abc.', '', null, undefined],
     password: ['not8', '', null, undefined]
   };


### PR DESCRIPTION
Slugs are validated like names used to be (except not necessarily present), and names are much looser than previously (only length and presence are required)