### PR TITLE
Fix broken profile links

### DIFF
--- a/app/templates/components/users/profile-links.hbs
+++ b/app/templates/components/users/profile-links.hbs
@@ -1,10 +1,10 @@
 {{#each (reject-by "isNew" true user.profileLinks) as |profile|}}
   {{#if profile.isURL}}
-    <a href={{profile}} target="_blank" rel="noopener noreferrer" class="profile-icon hint--top hint--bounce hint--rounded" aria-label={{profile.site.name}}>
+    <a href={{profile.url}} target="_blank" rel="noopener noreferrer" class="profile-icon hint--top hint--bounce hint--rounded" aria-label={{profile.site.name}}>
       {{svg-jar (profile-link-to-svg profile.site.name)}}
     </a>
   {{else}}
-    <a href="javascript:void();" class="profile-icon hint--top hint--bounce hint--rounded" aria-label={{concat profile.site.name ": " profile}} data-clipboard-text={{profile}} onclick={{action "copyNotification" profile}}>
+    <a href="javascript:void();" class="profile-icon hint--top hint--bounce hint--rounded" aria-label={{concat profile.site.name ": " profile.url}} data-clipboard-text={{profile.url}} onclick={{action "copyNotification" profile.url}}>
       {{svg-jar (profile-link-to-svg profile.site.name)}}
     </a>
   {{/if}}


### PR DESCRIPTION
I think this should fix this: https://kitsu.canny.io/bugs/p/profile-links-dont-work

Changes proposed in this pull request:

- Reverted the profile-link changes from 51690c9

/cc @hummingbird-me/staff
