### PR TITLE
Switch Search box to Algolia

### DIFF
--- a/app/components/application/nav-search.js
+++ b/app/components/application/nav-search.js
@@ -2,10 +2,12 @@ import Ember from 'ember';
 import { get, set, computed } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import jQuery from 'jquery';
+import { inject as service } from '@ember/service';
 
 export default Ember.Component.extend({
   isOpened: false,
   query: undefined,
+  algolia: service(),
 
   inputClass: computed('isOpened', 'query', function() {
     const isActive = get(this, 'isOpened') || isPresent(get(this, 'query'));
@@ -39,6 +41,10 @@ export default Ember.Component.extend({
   actions: {
     close() {
       set(this, 'isOpened', false);
+    },
+
+    loadKeys() {
+      get(this, 'algolia').loadKeys();
     }
   }
 });

--- a/app/components/search-results.js
+++ b/app/components/search-results.js
@@ -14,7 +14,7 @@ const INDICES = {
 
 const search = (indexName, attributesToRetrieve, hitsPerPage = 2) => (
   task(function* (query, options = {}) {
-    const index = yield get(this, 'algolia').indexFor(indexName);
+    const index = yield get(this, 'algolia.getIndex').perform(indexName);
     return yield index.search(query, {
       attributesToRetrieve,
       hitsPerPage,

--- a/app/components/search-results.js
+++ b/app/components/search-results.js
@@ -5,10 +5,11 @@ import { isEmpty } from '@ember/utils';
 import { task, timeout } from 'ember-concurrency';
 import { invokeAction } from 'ember-invoke-action';
 
+const DEFAULT_INCLUDED = ['id', 'slug', 'kind'];
 const INDICES = {
-  media: ['slug', 'canonicalTitle', 'titles', 'posterImage', 'kind', 'subtype', 'posterImage'],
-  users: ['slug', 'name', 'avatar'],
-  groups: ['slug', 'name', 'avatar'],
+  media: [...DEFAULT_INCLUDED, 'canonicalTitle', 'titles', 'posterImage', 'subtype', 'posterImage'],
+  users: [...DEFAULT_INCLUDED, 'name', 'avatar'],
+  groups: [...DEFAULT_INCLUDED, 'name', 'avatar'],
 };
 
 const search = (indexName, attributesToRetrieve) => (

--- a/app/components/search-results.js
+++ b/app/components/search-results.js
@@ -64,10 +64,10 @@ export default Component.extend({
   usersTask: search('users', INDICES.users),
   groupsTask: search('groups', INDICES.groups),
 
-  nextUsersPageTask: task(function* (page) {
+  nextPageTask: task(function* (kind, page) {
     const query = get(this, 'query');
-    const response = yield get(this, 'usersTask').perform(query, { page });
-    get(this, 'groups.users').addObjects(get(response, 'hits'));
+    const response = yield get(this, `${kind}Task`).perform(query, { page });
+    get(this, `groups.${kind}`).addObjects(get(response, 'hits'));
   }).drop(),
 
   actions: {

--- a/app/components/search-results.js
+++ b/app/components/search-results.js
@@ -12,12 +12,12 @@ const INDICES = {
   groups: [...DEFAULT_INCLUDED, 'name', 'avatar'],
 };
 
-const search = (indexName, attributesToRetrieve) => (
+const search = (indexName, attributesToRetrieve, hitsPerPage = 2) => (
   task(function* (query, options = {}) {
     const index = yield get(this, 'algolia').indexFor(indexName);
     return yield index.search(query, {
       attributesToRetrieve,
-      hitsPerPage: 2,
+      hitsPerPage,
       ...options
     });
   }).restartable()
@@ -60,9 +60,9 @@ export default Component.extend({
     yield timeout(250);
   }).keepLatest(),
 
-  mediaTask: search('media', INDICES.media),
-  usersTask: search('users', INDICES.users),
+  mediaTask: search('media', INDICES.media, 4),
   groupsTask: search('groups', INDICES.groups),
+  usersTask: search('users', INDICES.users),
 
   nextPageTask: task(function* (kind, page) {
     const query = get(this, 'query');

--- a/app/components/search-results/group.js
+++ b/app/components/search-results/group.js
@@ -29,7 +29,7 @@ export default Component.extend(Pagination, {
       if (typeOf(item) === 'string') {
         get(this, 'router.router').transitionTo(item);
       } else {
-        const type = get(item, 'modelType');
+        const type = get(item, 'kind');
         if (type === 'user') {
           get(this, 'router').transitionTo('users.index', [get(item, 'slug')]);
         } else if (type === 'group') {

--- a/app/components/search-results/group.js
+++ b/app/components/search-results/group.js
@@ -6,7 +6,7 @@ import { invokeAction } from 'ember-invoke-action';
 
 export default Component.extend({
   page: 0,
-  router: service('-routing'),
+  router: service(),
 
   didReceiveAttrs() {
     this._super(...arguments);
@@ -18,26 +18,29 @@ export default Component.extend({
 
   actions: {
     onPagination() {
+      set(this, 'isLoadingMore', true);
       const page = get(this, 'page') + 1;
       invokeAction(this, 'onPagination', page).then(() => {
         set(this, 'page', page);
         const hasNextPage = page !== (get(this, 'items.nbPages') - 1);
         set(this, 'hasNextPage', hasNextPage);
+      }).finally(() => {
+        set(this, 'isLoadingMore', false);
       });
     },
 
     transitionTo(item) {
       invokeAction(this, 'close');
       if (typeOf(item) === 'string') {
-        get(this, 'router.router').transitionTo(item);
+        get(this, 'router').transitionTo(item);
       } else {
         const type = get(item, 'kind');
         if (type === 'user') {
-          get(this, 'router').transitionTo('users.index', [get(item, 'slug')]);
+          get(this, 'router').transitionTo('users.index', get(item, 'slug'));
         } else if (type === 'group') {
-          get(this, 'router').transitionTo('groups.group.group-page.index', [get(item, 'slug')]);
+          get(this, 'router').transitionTo('groups.group.group-page.index', get(item, 'slug'));
         } else {
-          get(this, 'router').transitionTo(`${type}.show`, [get(item, 'slug')]);
+          get(this, 'router').transitionTo(`${type}.show`, get(item, 'slug'));
         }
       }
     }

--- a/app/components/search-results/group.js
+++ b/app/components/search-results/group.js
@@ -3,25 +3,27 @@ import { get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { typeOf } from '@ember/utils';
 import { invokeAction } from 'ember-invoke-action';
-import Pagination from 'kitsu-shared/mixins/pagination';
 
-export default Component.extend(Pagination, {
+export default Component.extend({
+  page: 0,
   router: service('-routing'),
 
   didReceiveAttrs() {
     this._super(...arguments);
-    this.updatePageState(get(this, 'items'));
-  },
-
-  onPagination(records) {
-    invokeAction(this, 'update', records);
-    set(this, 'isLoadingMore', false);
+    const items = get(this, 'items');
+    const pages = get(items, 'nbPages');
+    const hasNextPage = (pages > 1) && (get(this, 'page') !== (pages - 1));
+    set(this, 'hasNextPage', hasNextPage);
   },
 
   actions: {
     onPagination() {
-      set(this, 'isLoadingMore', true);
-      this._super();
+      const page = get(this, 'page') + 1;
+      invokeAction(this, 'onPagination', page).then(() => {
+        set(this, 'page', page);
+        const hasNextPage = page !== (get(this, 'items.nbPages') - 1);
+        set(this, 'hasNextPage', hasNextPage);
+      });
     },
 
     transitionTo(item) {

--- a/app/components/search-results/row.js
+++ b/app/components/search-results/row.js
@@ -6,6 +6,7 @@ export default Component.extend({
   kind: alias('item.kind'),
   imageUrl: or('item.avatar', 'item.posterImage'),
   title: or('item.name', 'item.canonicalTitle'),
+  slug: or('item.slug', 'item.id'),
 
   imageClass: computed('item.kind', function () {
     const kind = get(this, 'item.kind');

--- a/app/components/search-results/row.js
+++ b/app/components/search-results/row.js
@@ -1,22 +1,16 @@
 import Component from '@ember/component';
 import { get, computed } from '@ember/object';
 import { alias, or } from '@ember/object/computed';
-import getTitleField from 'client/utils/get-title-field';
+import { getComputedTitle } from 'client/utils/get-title-field';
 
 export default Component.extend({
   kind: alias('item.kind'),
   imageUrl: or('item.avatar', 'item.posterImage'),
-  title: or('item.name', 'item.computedTitle'),
+  title: or('item.name', 'computedTitle'),
   slug: or('item.slug', 'item.id'),
 
   computedTitle: computed('session.account.titleLanguagePreference', 'item.titles', function() {
-    if (!get(this, 'session.hasUser')) {
-      return get(this, 'item.canonicalTitle');
-    }
-    const preference = get(this, 'session.account.titleLanguagePreference').toLowerCase();
-    const key = getTitleField(preference);
-    return key !== undefined ? get(this, `item.titles.${key}`) || get(this, 'item.canonicalTitle') :
-      get(this, 'item.canonicalTitle');
+    return getComputedTitle(get(this, 'session'), get(this, 'item'));
   }).readOnly(),
 
   imageClass: computed('item.kind', function () {

--- a/app/components/search-results/row.js
+++ b/app/components/search-results/row.js
@@ -1,0 +1,42 @@
+import Component from '@ember/component';
+import { get, computed } from '@ember/object';
+import { alias, or } from '@ember/object/computed';
+
+export default Component.extend({
+  kind: alias('item.kind'),
+  imageUrl: or('item.avatar', 'item.posterImage'),
+  title: or('item.name', 'item.canonicalTitle'),
+
+  imageClass: computed('item.kind', function () {
+    const kind = get(this, 'item.kind');
+    switch (kind) {
+      case 'user':
+      case 'group':
+        return `is-avatar-${kind}s`;
+      default:
+        return '';
+    }
+  }),
+
+  route: computed('item.kind', function () {
+    const kind = get(this, 'item.kind');
+    switch (kind) {
+      case 'user':
+        return 'users.index';
+      case 'group':
+        return 'groups.group.group-page.index';
+      default:
+        return `${kind}.show`;
+    }
+  }),
+
+  tags: computed('item.kind', 'item.subtype', 'item.nsfw', function () {
+    const kind = get(this, 'item.kind');
+    const subtype = get(this, 'item.subtype');
+    const nsfw = get(this, 'item.nsfw');
+    const out = [];
+    if (subtype) out.push(`media-shared.types.${kind}.${subtype.toLowerCase()}`);
+    if (nsfw) out.push('groups.nsfw');
+    return out;
+  })
+});

--- a/app/components/search-results/row.js
+++ b/app/components/search-results/row.js
@@ -20,6 +20,7 @@ export default Component.extend({
 
   route: computed('item.kind', function () {
     const kind = get(this, 'item.kind');
+    if (!kind) return 'not-found';
     switch (kind) {
       case 'user':
         return 'users.index';

--- a/app/models/media.js
+++ b/app/models/media.js
@@ -4,7 +4,7 @@ import { hasMany } from 'ember-data/relationships';
 import { get, computed } from '@ember/object';
 import { or } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import getTitleField from 'client/utils/get-title-field';
+import { getComputedTitle } from 'client/utils/get-title-field';
 
 export default Base.extend({
   session: service(),
@@ -36,13 +36,7 @@ export default Base.extend({
 
   unitCount: or('episodeCount', 'chapterCount'),
   computedTitle: computed('session.account.titleLanguagePreference', 'titles', function() {
-    if (!get(this, 'session.hasUser')) {
-      return get(this, 'canonicalTitle');
-    }
-    const preference = get(this, 'session.account.titleLanguagePreference').toLowerCase();
-    const key = getTitleField(preference);
-    return key !== undefined ? get(this, `titles.${key}`) || get(this, 'canonicalTitle') :
-      get(this, 'canonicalTitle');
+    return getComputedTitle(get(this, 'session'), this);
   }).readOnly(),
 
   year: computed('startDate', function() {

--- a/app/services/algolia.js
+++ b/app/services/algolia.js
@@ -1,0 +1,23 @@
+import { get, set } from '@ember/object';
+import Service, { inject as service } from '@ember/service';
+import { task } from 'ember-concurrency';
+import algoliasearch from 'algoliasearch';
+import config from 'client/config/environment';
+
+export default Service.extend({
+  ajax: service(),
+  keys: {},
+
+  loadKeys: task(function* () {
+    const ajax = get(this, 'ajax');
+    const keys = yield ajax.request('/algolia-keys', { method: 'GET' });
+    set(this, 'keys', keys);
+  }),
+
+  async indexFor(name) {
+    if (!get(this, `keys.${name}`)) await this.loadKeys.perform();
+    const info = get(this, `keys.${name}`);
+    const client = algoliasearch(config.algolia.appId, info.key);
+    return client.initIndex(info.index);
+  }
+});

--- a/app/services/algolia.js
+++ b/app/services/algolia.js
@@ -20,13 +20,13 @@ export default Service.extend({
     set(this, 'keys', keys);
   }).drop(),
 
-  async indexFor(name) {
+  getIndex: task(function* (name) {
     if (get(this, `indices.${name}`)) return get(this, `indices.${name}`);
-    await this.loadKeys();
+    yield this.loadKeys();
     const info = get(this, `keys.${name}`);
     const client = algoliasearch(config.algolia.appId, info.key);
     const index = client.initIndex(info.index);
     set(this, `indices.${name}`, index);
     return index;
-  }
+  })
 });

--- a/app/services/algolia.js
+++ b/app/services/algolia.js
@@ -7,17 +7,21 @@ import config from 'client/config/environment';
 export default Service.extend({
   ajax: service(),
   keys: {},
+  indices: {},
 
   loadKeys: task(function* () {
     const ajax = get(this, 'ajax');
     const keys = yield ajax.request('/algolia-keys', { method: 'GET' });
     set(this, 'keys', keys);
-  }),
+  }).drop(),
 
   async indexFor(name) {
-    if (!get(this, `keys.${name}`)) await this.loadKeys.perform();
+    if (!get(this, `keys.${name}`)) await get(this, 'loadKeys').perform();
+    if (get(this, `indices.${name}`)) return get(this, `indices.${name}`);
     const info = get(this, `keys.${name}`);
     const client = algoliasearch(config.algolia.appId, info.key);
-    return client.initIndex(info.index);
+    const index = client.initIndex(info.index);
+    set(this, `indices.${name}`, index);
+    return index;
   }
 });

--- a/app/templates/components/application/nav-search.hbs
+++ b/app/templates/components/application/nav-search.hbs
@@ -10,6 +10,7 @@
   class=inputClass
   placeholder="Search Kitsu"
   autocomplete="off"
+  focusIn=(action 'loadKeys')
 }}
 
 {{search-results

--- a/app/templates/components/search-results.hbs
+++ b/app/templates/components/search-results.hbs
@@ -28,7 +28,8 @@
           group="users"
           items=groups.users
           isLoading=usersTask.isRunning
-          update=(action "updatePage")
+          isLoadingMore=nextUsersPageTask.isRunning
+          onPagination=(perform nextUsersPageTask)
           close=(action "close")}}
       </div>
     </div>

--- a/app/templates/components/search-results.hbs
+++ b/app/templates/components/search-results.hbs
@@ -10,19 +10,11 @@
     <div class="search--drop">
       <p class="search--header">Search Results</p>
       <div style="overflow: auto">
-        {{! anime group }}
+        {{! media group }}
         {{search-results/group
-          group="anime"
-          items=groups.anime
-          isLoading=animeTask.isRunning
-          moreLink=(href-to "anime.index" (query-params text=query))
-          close=(action "close")}}
-        {{! manga group }}
-        {{search-results/group
-          group="manga"
-          items=groups.manga
-          isLoading=mangaTask.isRunning
-          moreLink=(href-to "manga.index" (query-params text=query))
+          group="media"
+          items=groups.media
+          isLoading=mediaTask.isRunning
           close=(action "close")}}
         {{! groups group }}
         {{search-results/group

--- a/app/templates/components/search-results.hbs
+++ b/app/templates/components/search-results.hbs
@@ -15,6 +15,7 @@
           group="media"
           items=groups.media
           isLoading=mediaTask.isRunning
+          onPagination=(perform nextPageTask "media")
           close=(action "close")}}
         {{! groups group }}
         {{search-results/group
@@ -28,8 +29,7 @@
           group="users"
           items=groups.users
           isLoading=usersTask.isRunning
-          isLoadingMore=nextUsersPageTask.isRunning
-          onPagination=(perform nextUsersPageTask)
+          onPagination=(perform nextPageTask "users")
           close=(action "close")}}
       </div>
     </div>

--- a/app/templates/components/search-results/group.hbs
+++ b/app/templates/components/search-results/group.hbs
@@ -18,7 +18,7 @@
 </div>
 
 <ul class="nav">
-  {{#if isLoading}}
+  {{#if (and isLoading (not isLoadingMore))}}
     <div class="text-xs-center w-100 m-t-1 m-b-1">
       {{loading-spinner size="small"}}
     </div>

--- a/app/templates/components/search-results/group.hbs
+++ b/app/templates/components/search-results/group.hbs
@@ -27,20 +27,23 @@
       {{#each items as |item|}}
         <li class="media col-sm-12" {{action "transitionTo" item}}>
           <div class="media-left col-sm-2 no-padding-left">
-            {{#if (or (eq group "users") (eq group "groups"))}}
+            {{#if (or (eq item.kind "user") (eq item.kind "group"))}}
               {{lazy-image src=(image item.avatar "small") imgClass=(concat "is-avatar-" group)}}
             {{else}}
               {{lazy-image src=(image item.posterImage "small")}}
             {{/if}}
           </div>
           <div class="media-body col-sm no-padding-left">
-            {{#if (or (eq group "users") (eq group "groups"))}}
+            {{#if (or (eq item.kind "user") (eq item.kind "group"))}}
               <p>{{item.name}}</p>
             {{else}}
-              <p>{{item.computedTitle}}</p>
+              <p>{{item.canonicalTitle}}</p>
             {{/if}}
           </div>
-          {{#if (and (eq group "groups") item.nsfw)}}
+          {{#if (eq group "media")}}
+            <span class="tag tag-default">{{item.subtype}}</span>
+          {{/if}}
+          {{#if (and (eq item.kind "group") item.nsfw)}}
             <span class="tag tag-default">{{t "groups.nsfw"}}</span>
           {{/if}}
         </li>

--- a/app/templates/components/search-results/group.hbs
+++ b/app/templates/components/search-results/group.hbs
@@ -23,30 +23,9 @@
       {{loading-spinner size="small"}}
     </div>
   {{else if items}}
-    <ul class="media-list search--results">
+    <div class="media-list search--results">
       {{#each items as |item|}}
-        <li class="media col-sm-12" {{action "transitionTo" item}}>
-          <div class="media-left col-sm-2 no-padding-left">
-            {{#if (or (eq item.kind "user") (eq item.kind "group"))}}
-              {{lazy-image src=(image item.avatar "small") imgClass=(concat "is-avatar-" group)}}
-            {{else}}
-              {{lazy-image src=(image item.posterImage "small")}}
-            {{/if}}
-          </div>
-          <div class="media-body col-sm no-padding-left">
-            {{#if (or (eq item.kind "user") (eq item.kind "group"))}}
-              <p>{{item.name}}</p>
-            {{else}}
-              <p>{{item.canonicalTitle}}</p>
-            {{/if}}
-          </div>
-          {{#if (eq group "media")}}
-            <span class="tag tag-default">{{item.subtype}}</span>
-          {{/if}}
-          {{#if (and (eq item.kind "group") item.nsfw)}}
-            <span class="tag tag-default">{{t "groups.nsfw"}}</span>
-          {{/if}}
-        </li>
+        {{search-results/row item=item}}
       {{/each}}
 
       {{#if isLoadingMore}}
@@ -54,6 +33,6 @@
           {{loading-spinner size="small"}}
         </div>
       {{/if}}
-    </ul>
+    </div>
   {{/if}}
 </ul>

--- a/app/templates/components/search-results/group.hbs
+++ b/app/templates/components/search-results/group.hbs
@@ -3,10 +3,10 @@
   <div class="pull-sm-right">
     {{#if items}}
       {{#if moreLink}}
-        <a href="#" {{action "transitionTo" moreLink}}>more</a>
+        <a href="#" {{action "transitionTo" moreLink}}>view more</a>
       {{else}}
         {{#if hasNextPage}}
-          <a href="#" {{action "onPagination"}}>more</a>
+          <a href="#" {{action "onPagination"}}>load more</a>
         {{/if}}
       {{/if}}
     {{else}}

--- a/app/templates/components/search-results/row.hbs
+++ b/app/templates/components/search-results/row.hbs
@@ -1,4 +1,4 @@
-<a class="media col-sm-12" href={{href-to route item.slug}}>
+<a class="media col-sm-12" href={{href-to route slug}}>
   <div class="media-left col-sm-2 no-padding-left">
     {{lazy-image src=(image imageUrl "small") imgClass=imageClass}}
   </div>

--- a/app/templates/components/search-results/row.hbs
+++ b/app/templates/components/search-results/row.hbs
@@ -1,0 +1,11 @@
+<a class="media col-sm-12" href={{href-to route item.slug}}>
+  <div class="media-left col-sm-2 no-padding-left">
+    {{lazy-image src=(image imageUrl "small") imgClass=imageClass}}
+  </div>
+  <div class="media-body col-sm no-padding-left">
+    <p>{{title}}</p>
+  </div>
+  {{#each tags as |tag|}}
+    <span class="tag tag-default">{{t tag}}</span>
+  {{/each}}
+</a>

--- a/app/utils/get-title-field.js
+++ b/app/utils/get-title-field.js
@@ -1,4 +1,6 @@
-export default function getTitleField(preference) {
+import { get } from '@ember/object';
+
+export function getTitleField(preference) {
   switch (preference) {
     case 'english':
       return 'en';
@@ -8,3 +10,18 @@ export default function getTitleField(preference) {
       return 'canonical';
   }
 }
+
+export function getComputedTitle(session, context) {
+  if (!get(session, 'hasUser')) {
+    return get(context, 'canonicalTitle');
+  }
+  const preference = get(session, 'account.titleLanguagePreference').toLowerCase();
+  const key = getTitleField(preference);
+  return key !== undefined ? get(context, `titles.${key}`) || get(context, 'canonicalTitle') :
+    get(context, 'canonicalTitle');
+}
+
+export default {
+  getTitleField,
+  getComputedTitle
+};

--- a/config/environment.js
+++ b/config/environment.js
@@ -103,6 +103,10 @@ module.exports = function(environment) {
       }
     },
 
+    algolia: {
+      appId: 'AWQO5J657S'
+    },
+
     moment: {
       allowEmpty: true,
       includeTimezone: 'subset'

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -112,6 +112,11 @@ module.exports = function(defaults) {
   // Work around for Ember 2.16.2 and Sourcemaps in production
   app.import('node_modules/showdown/dist/showdown.js.map', { destDir: 'assets' });
   app.import('node_modules/zxcvbn/dist/zxcvbn.js.map', { destDir: '.' });
+  app.import('node_modules/algoliasearch/dist/algoliasearchLite.min.js', {
+    using: [
+      { transformation: 'amd', as: 'algoliasearch' }
+    ]
+  });
 
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Kitsu, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
+    "algoliasearch": "^3.24.7",
     "autoprefixer": "^7.1.5",
     "autosize": "^4.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/tests/unit/utils/get-title-field-test.js
+++ b/tests/unit/utils/get-title-field-test.js
@@ -1,5 +1,5 @@
-import getTitleField from 'client/utils/get-title-field';
 import { module, test } from 'qunit';
+import { getTitleField, getComputedTitle } from 'client/utils/get-title-field';
 
 module('Unit | Utility | get title field');
 
@@ -16,4 +16,22 @@ test('it returns `en_jp` for `romanized`', function(assert) {
 test('it returns `canonical` as default', function(assert) {
   const result = getTitleField('something_else');
   assert.equal(result, 'canonical');
+});
+
+test('it returns canonicalTitle when there is no session', function(assert) {
+  const result = getComputedTitle({ hasUser: false }, { canonicalTitle: 'Hello, World!' });
+  assert.equal(result, 'Hello, World!');
+});
+
+test('it returns session preference', function(assert) {
+  const session = { hasUser: true, account: { titleLanguagePreference: 'romanized' } };
+  const media = { titles: { en_jp: 'Shinjeki no Kyojin', en: 'Attack on Titan' }, canonicalTitle: 'Attack on Titan' };
+  let result = getComputedTitle(session, media);
+  assert.equal(result, 'Shinjeki no Kyojin');
+  session.account.titleLanguagePreference = 'english';
+  result = getComputedTitle(session, media);
+  assert.equal(result, 'Attack on Titan');
+  session.account.titleLanguagePreference = 'nothingburger';
+  result = getComputedTitle(session, media);
+  assert.equal(result, 'Attack on Titan');
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,10 @@ after@0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.1.tgz#ab5d4fb883f596816d3515f8f791c0af486dd627"
 
+agentkeepalive@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-2.2.0.tgz#c5d1bd4b129008f1163f236f86e5faea2026e2ef"
+
 ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -100,6 +104,26 @@ ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+algoliasearch@^3.24.7:
+  version "3.24.7"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.24.7.tgz#7ba6c41c9c87b3d36c3181e1d93d482b2ae1a660"
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.8"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -2436,6 +2460,10 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
 domelementtype@1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
@@ -3759,6 +3787,13 @@ entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+envify@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/envify/-/envify-4.1.0.tgz#f39ad3db9d6801b4e6b478b61028d3f0b6819f7e"
+  dependencies:
+    esprima "^4.0.0"
+    through "~2.3.4"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -3797,6 +3832,10 @@ es6-map@^0.1.4:
     es6-set "~0.1.5"
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
+
+es6-promise@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.1.tgz#8811e90915d9a0dba36274f0b242dbda78f9c92a"
 
 es6-set@~0.1.5:
   version "0.1.5"
@@ -4011,6 +4050,10 @@ eventemitter3@1.x.x:
 events-to-array@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.1.2.tgz#2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6"
+
+events@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
 exec-sh@^0.2.0:
   version "0.2.1"
@@ -4639,6 +4682,13 @@ global-prefix@^0.1.4:
     is-windows "^0.2.0"
     which "^1.2.12"
 
+global@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
+
 globals@^6.4.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/globals/-/globals-6.4.1.tgz#8498032b3b6d1cc81eebc5f79690d8fe29fabf4f"
@@ -5214,6 +5264,10 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isarray@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.2.tgz#5aa99638daf2248b10b9598b763a045688ece3ee"
+
 isbinaryfile@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-3.0.2.tgz#4a3e974ec0cba9004d3fc6cde7209ea69368a621"
@@ -5540,6 +5594,10 @@ load-json-file@^2.0.0:
     parse-json "^2.2.0"
     pify "^2.0.0"
     strip-bom "^3.0.0"
+
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
 
 loader.js@^4.6.0:
   version "4.6.0"
@@ -6144,6 +6202,12 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
+
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -6459,7 +6523,7 @@ object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
 
-object-keys@^1.0.10, object-keys@^1.0.8:
+object-keys@^1.0.10, object-keys@^1.0.11, object-keys@^1.0.8, object-keys@~1.0.0:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
@@ -6794,6 +6858,10 @@ process-relative-require@^1.0.0:
   dependencies:
     node-modules-path "^1.0.0"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
@@ -6842,6 +6910,10 @@ qs@~6.3.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+querystring-es3@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
 
 quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
   version "0.1.8"
@@ -7018,6 +7090,12 @@ redeyed@~1.0.0:
   resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-1.0.1.tgz#e96c193b40c0816b00aec842698e61185e55498a"
   dependencies:
     esprima "~3.0.0"
+
+reduce@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/reduce/-/reduce-1.0.1.tgz#14fa2e5ff1fc560703a020cbb5fbaab691565804"
+  dependencies:
+    object-keys "~1.0.0"
 
 regenerate@^1.2.1:
   version "1.3.3"
@@ -7984,7 +8062,7 @@ text-table@~0.2.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.1.0.tgz#1be0dc2a0dc244d44be8a09af6a85afb93c4dbc3"
 
-through@^2.3.6, through@^2.3.8, through@~2.3.8:
+through@^2.3.6, through@^2.3.8, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
Switches the main site search to use Algolia instead of ElasticSearch and fixes "Open in New Tab" for search results.

Design changes:

* Result text is now orange because of actually using `a` tags
* Anime and Manga are comingled under Media
* Media no longer has a "MORE" link because we don't have a comingled explore page
* Media results show their subtype (OVA/ONA/Manhua/etc.)
* Users don't paginate because I can't figure out how that code works???