### PR TITLE
Handle errors during session initialization

### DIFF
--- a/app/components/application/session-error.js
+++ b/app/components/application/session-error.js
@@ -1,0 +1,12 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+
+export default Component.extend({
+  session: service(),
+
+  actions: {
+    reload() {
+      window.location.reload();
+    }
+  }
+});

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -2,6 +2,7 @@ import Session from 'ember-simple-auth/services/session';
 import { get, set, computed } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import { inject as service } from '@ember/service';
+import { run } from '@ember/runloop';
 import { UnauthorizedError } from 'ember-data';
 import Raven from 'client/services/raven';
 import jQuery from 'jquery';
@@ -46,7 +47,7 @@ export default Session.extend({
       // If no user was found, throw an unauthorized error
       if (!user) throw new UnauthorizedError();
 
-      set(this, 'account', user);
+      run(() => set(this, 'account', user));
       return user;
     } catch (error) {
       const status = get(error, 'errors.firstObject.status');
@@ -55,7 +56,7 @@ export default Session.extend({
         Raven.captureException(error);
       } else {
         Raven.captureException(error);
-        this.invalidate();
+        run(() => this.invalidate());
         throw error;
       }
     }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -42,10 +42,11 @@ export default Session.extend({
     const { store, raven } = getProperties(this, 'store', 'raven');
     try {
       // Load the current user
-      const user = get(await store.query('user', {
+      const users = await store.query('user', {
         filter: { self: true },
         include: 'userRoles.role,userRoles.user'
-      }), 'firstObject');
+      });
+      const user = get(users, 'firstObject');
       // If no user was found, throw an unauthorized error
       if (!user) throw new DS.UnauthorizedError();
 

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -10,6 +10,8 @@ export default Session.extend({
   store: service(),
   raven: service(),
 
+  error: null,
+
   hasUser: computed('isAuthenticated', 'account', function() {
     return get(this, 'isAuthenticated') && isPresent(get(this, 'account'));
   }).readOnly(),
@@ -53,6 +55,7 @@ export default Session.extend({
       const status = get(error, 'errors.firstObject.status');
       // Capture 5xx errors but don't invalidate the session
       if (status && status.charAt(0) === '5') {
+        set(this, 'error', 'serverError');
         raven.captureException(error);
       } else {
         raven.captureException(error);

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,13 +1,13 @@
 import Session from 'ember-simple-auth/services/session';
-import { get, set, computed, getProperties } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import { UnauthorizedError } from 'ember-data';
+import Raven from 'client/services/raven';
 import jQuery from 'jquery';
 
 export default Session.extend({
   store: service(),
-  raven: service(),
 
   hasUser: computed('isAuthenticated', 'account', function() {
     return get(this, 'isAuthenticated') && isPresent(get(this, 'account'));
@@ -36,7 +36,7 @@ export default Session.extend({
    * Get the account information for the sessioned user
    */
   async getCurrentUser() {
-    const { store, raven } = getProperties(this, 'store', 'raven');
+    const store = get(this, 'store');
     try {
       // Load the current user
       const user = get(await store.query('user', {
@@ -52,9 +52,9 @@ export default Session.extend({
       const status = get(error, 'errors.firstObject.status');
       // Capture 5xx errors but don't invalidate the session
       if (status.charAt(0) === '5') {
-        raven.captureException(error);
+        Raven.captureException(error);
       } else {
-        raven.captureException(error);
+        Raven.captureException(error);
         this.invalidate();
         throw error;
       }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,9 @@
 {{! header }}
 {{application/site-header}}
 
+{{! session error message }}
+{{application/session-error}}
+
 {{! loading indicator }}
 {{#if routeIsLoading}}
   <div class="loading-bar"></div>

--- a/app/templates/components/application/session-error.hbs
+++ b/app/templates/components/application/session-error.hbs
@@ -1,0 +1,17 @@
+{{#if session.error}}
+  {{#bootstrap/bs-modal keyboard='false' backdrop='static' onClose=(action "reload") as |modal|}}
+    {{#modal.header}}
+      <h4 class="modal-title">
+        {{t "errors.serverError.title"}}
+      </h4>
+    {{/modal.header}}
+    {{#modal.body}}
+      {{t "errors.serverError.body"}}
+    {{/modal.body}}
+    {{#modal.footer}}
+      {{#bootstrap/bs-button onClick=(action "reload") type="btn-primary"}}
+        Reload
+      {{/bootstrap/bs-button}}
+    {{/modal.footer}}
+  {{/bootstrap/bs-modal}}
+{{/if}}

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -9,7 +9,8 @@ moduleFor('route:application', 'Unit | Route | application', {
     'service:router-scroll',
     'service:scheduler',
     'service:intl',
-    'service:moment'
+    'service:moment',
+    'service:raven'
   ]
 });
 

--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -35,13 +35,13 @@ test('#isCurrentUser tests if the passed user is the current user', function(ass
   assert.notOk(result);
 });
 
-test('#getCurrentUser retrieves the user and sets account', function(assert) {
+test('#getCurrentUser retrieves the user and sets account', async function(assert) {
   assert.expect(1);
   const user = run(() => this.store.createRecord('user', { name: 'Holo' }));
   sinon.stub(this.store, 'query').returns([user]);
   const service = this.subject({ store: this.store });
-  service.getCurrentUser();
-  return wait().then(() => assert.equal(get(service, 'account.name'), 'Holo'));
+  await service.getCurrentUser();
+  return assert.equal(get(service, 'account.name'), 'Holo');
 });
 
 test('#getCurrentUser captures 5xx errors and returns nothing', function(assert) {

--- a/tests/unit/services/session-test.js
+++ b/tests/unit/services/session-test.js
@@ -5,7 +5,6 @@ import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import DS from 'ember-data';
 import setupStore from 'client/tests/helpers/setup-store';
-import wait from 'ember-test-helpers/wait';
 import sinon from 'sinon';
 
 moduleFor('service:session', 'Unit | Service | session', {
@@ -41,16 +40,16 @@ test('#getCurrentUser retrieves the user and sets account', async function(asser
   sinon.stub(this.store, 'query').returns([user]);
   const service = this.subject({ store: this.store });
   await service.getCurrentUser();
-  return assert.equal(get(service, 'account.name'), 'Holo');
+  assert.equal(get(service, 'account.name'), 'Holo');
 });
 
-test('#getCurrentUser captures 5xx errors and returns nothing', function(assert) {
+test('#getCurrentUser captures 5xx errors and returns nothing', async function(assert) {
   assert.expect(1);
   const error = new DS.ServerError([{ status: '503' }]);
   sinon.stub(this.store, 'query').throws(error);
   const service = this.subject({ store: this.store });
-  service.getCurrentUser();
-  return wait().then(() => assert.notOk());
+  await service.getCurrentUser();
+  assert.notOk();
 });
 
 test('#getCurrentUser captures 4xx errors and invalidates session', function(assert) {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1165,6 +1165,9 @@ errors:
   load: "There was an issue loading the content."
   contentEmpty: "Hmm, there doesn't seem to be anything here yet."
   request: "Oops! Something went wrong with the request."
+  serverError:
+    title: "Oops! Looks like our server has a bug."
+    body: "Our team has been notified, please try again in a few minutes."
 # Loading
 loading: "Loading {subject, select,
   episode {Episode}


### PR DESCRIPTION
# Error Handling
<s>For a 5xx error, ignore the issue.  We should probably change this to display a modal based on the error code (500 = try again, 502/503/504 = wait a few minutes and try again, 503 with `X-Kitsu-Maintenance` header set = scheduled maintenance info)</s>

Update: for a 5xx error, show a modal which, when closed, triggers a reload

For other errors, continue to invalidate the session, but make sure it's sent to Sentry so that it can be tracked.

# Refactoring of `getCurrentUser`
Switched from Promise-based code to the awesomeness that is async/await.  My favorite thing has to be that I can stub out `await`-ed functions and return a non-Promise value and it just treats it as if it were wrapped in `Promise.resolve()`

# Testing
I opted to stub the store method because it was just easier than using Mirage