### PR TITLE
Add library status dropdowns to franchise page

### DIFF
--- a/app/templates/media/show/franchise.hbs
+++ b/app/templates/media/show/franchise.hbs
@@ -19,6 +19,7 @@
                   {{lazy-image src=(image destination.posterImage "medium")}}
                   <div class="poster-overlay">
                     <a href={{href-to (concat destination.modelType ".show") destination.slug}}></a>
+                    {{library-entry/status-dropdown media=destination}}
                   </div>
                 </div>
               {{/media-popover}}


### PR DESCRIPTION
Ref: https://kitsu.canny.io/feature-requests/p/library-status-missing-on-franchise-media

Changes proposed in this pull request:

- add missing status dropdown

/cc @hummingbird-me/staff
