### PR TITLE
When replying, fallback from slug to ID

### DIFF
--- a/app/components/stream-feed/items/post/comment.js
+++ b/app/components/stream-feed/items/post/comment.js
@@ -164,7 +164,8 @@ export default Component.extend(ClipboardMixin, Pagination, CanMixin, {
       if (get(this, 'isTopLevel') === true) {
         this.toggleProperty('isReplying');
       } else {
-        invokeAction(this, 'onReply', get(this, 'comment.user.slug'));
+        const mention = get(this, 'comment.user.slug') || get(this, 'comment.user.id');
+        invokeAction(this, 'onReply', mention);
       }
     },
 


### PR DESCRIPTION
@mentions need to support ID as well as slug, at least until we set up a rich text editor to hide this detail