### PR TITLE
Preserve aspect ratio on quick update images

### DIFF
--- a/app/styles/layout/_quick-update.scss
+++ b/app/styles/layout/_quick-update.scss
@@ -378,5 +378,6 @@ a.update--entry-title {
   }
   .lazy-image img {
     min-height: 200px;
+    object-fit: cover;
   }
 }


### PR DESCRIPTION
Ref: https://kitsu.canny.io/bugs/p/quick-update-images-look-distorted

Changes proposed in this pull request:

- override object-fit on quick update images

/cc @hummingbird-me/staff
