### PR TITLE
Format group about panel

### DIFF
--- a/app/styles/layout/_sidebars.scss
+++ b/app/styles/layout/_sidebars.scss
@@ -216,3 +216,11 @@
     }
   }
 }
+
+.group-about-me-panel {
+  @include word-break();
+  font-size: 14px;
+  p {
+    white-space: pre-line;
+  }
+}

--- a/app/templates/groups/group/group-page/index.hbs
+++ b/app/templates/groups/group/group-page/index.hbs
@@ -18,7 +18,7 @@
 
     {{! Sidebar }}
     <div class="feed-sidebar col-sm-4">
-      <div class="sidebar-item">
+      <div class="group-about-me-panel sidebar-item">
         <h6 class="panel-heading">{{t "groups.activity.about" group=group.name}}</h6>
         <p>
           {{#if group.about}}


### PR DESCRIPTION
Ref: https://kitsu.canny.io/bugs/p/group-description-needs-a-css-rule-for-line-wrap

Changes proposed in this pull request:

- styles the group about me panel like the one on profiles

/cc @hummingbird-me/staff
