### PR TITLE
Fix extra newline in group about

### DIFF
--- a/app/templates/groups/group/group-page/index.hbs
+++ b/app/templates/groups/group/group-page/index.hbs
@@ -20,13 +20,7 @@
     <div class="feed-sidebar col-sm-4">
       <div class="group-about-me-panel sidebar-item">
         <h6 class="panel-heading">{{t "groups.activity.about" group=group.name}}</h6>
-        <p>
-          {{#if group.about}}
-            {{group.about}}
-          {{else}}
-            {{t "errors.contentEmpty"}}
-          {{/if}}
-        </p>
+        <p>{{group.about}}</p>
       </div>
 
       {{! Group Members }}

--- a/app/templates/groups/group/group-page/index.hbs
+++ b/app/templates/groups/group/group-page/index.hbs
@@ -20,7 +20,13 @@
     <div class="feed-sidebar col-sm-4">
       <div class="group-about-me-panel sidebar-item">
         <h6 class="panel-heading">{{t "groups.activity.about" group=group.name}}</h6>
-        <p>{{group.about}}</p>
+        <p>
+          {{~#if group.about}}
+            {{~group.about}}
+          {{~else}}
+            {{~t "errors.contentEmpty"}}
+          {{~/if~}}
+        </p>
       </div>
 
       {{! Group Members }}


### PR DESCRIPTION
Following up on #590, this should remove an extra newline that was being inserted before the group about section.

Changes proposed in this pull request:

- make group about display the same as the user about section

/cc @hummingbird-me/staff
