### PR TITLE
Fix comment wrapping

### DIFF
--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -533,7 +533,7 @@
   .media-body {
     font-size: 14px;
     .comment-body {
-      @include word-break(all);
+      @include word-break();
       margin-bottom: 0;
       display: inline;
       @if $theme == 'kitsu-dark' {


### PR DESCRIPTION
Ref: https://kitsu.canny.io/bugs/p/words-are-being-split-in-posts-and-comments-on-firefox

Changes proposed in this pull request:

- don't `break-all` on comments

/cc @hummingbird-me/staff
