### PR TITLE
Disable media sidebar ad

### DIFF
--- a/app/templates/components/media/media-summary.hbs
+++ b/app/templates/components/media/media-summary.hbs
@@ -13,7 +13,7 @@
 </div>
 
 {{! Kitsu Media Summary Sidebar }}
-{{ad-unit unit="kitsu.media.summary.sidebar"
+{{!ad-unit unit="kitsu.media.summary.sidebar"
   targeting=(hash
     section="media"
     media=media.slug)


### PR DESCRIPTION
Ref: https://kitsu.canny.io/bugs/p/anime-info-section-misplaced

Considering ads don't seem to be working right now, I think changing the ad sizes can be done another time.

Changes proposed in this pull request:

- remove ad to prevent displacement of media information

/cc @hummingbird-me