### PR TITLE
Fix cutoff input areas in library edit modal

### DIFF
--- a/app/styles/layout/_modals.scss
+++ b/app/styles/layout/_modals.scss
@@ -691,4 +691,9 @@
       }
     }
   }
+  .input-group {
+    .form-control {
+      min-width: 50px;
+    }
+  }
 }


### PR DESCRIPTION
Ref: https://kitsu.canny.io/bugs/p/editing-entries-not-fully-shown-firefox

This should fix the inputs from extending outside the modal on browsers other than Chrome.

Changes proposed in this pull request:

- set a `min-width` on the affected input elements

/cc @hummingbird-me/staff
