### PR TITLE
Fix tiny episode/chapter list

### DIFF
--- a/app/styles/pages/_media-pages.scss
+++ b/app/styles/pages/_media-pages.scss
@@ -2,6 +2,7 @@
   margin-left: 205px;
   max-width: 910px;
   .row {
+    display: block;
     width: 100%;
   }
   @media (max-width: 767px) {


### PR DESCRIPTION
The episode/chapter list gets really small when there are less than 3 episodes/chapters:

![https://puu.sh/AsJoy/afc22fb55b.png](https://puu.sh/AsJoy/afc22fb55b.png)

Changes proposed in this pull request:

- changed the parent of the flex element to block

/cc @hummingbird-me/staff
