### PR TITLE
Restrict size of videos in comments

### DIFF
--- a/app/styles/components/_onebox.scss
+++ b/app/styles/components/_onebox.scss
@@ -5,6 +5,13 @@
     max-height: 400px;
   }
 }
+.comment-body {
+  video {
+    max-width: 100%;
+    height: auto;
+    max-height: 250px;
+  }
+}
 
 .imgur-album {
   border-radius: 3px;


### PR DESCRIPTION
Ref: https://kitsu.canny.io/bugs/p/gif-comments-size-isnt-reduced-to-fit-the-comment-window


/cc @hummingbird-me
