### PR TITLE
Fix size of group sidebar

### DIFF
--- a/app/templates/groups/group/group-page/index.hbs
+++ b/app/templates/groups/group/group-page/index.hbs
@@ -24,7 +24,7 @@
     </div>
 
     {{! Sidebar }}
-    <div class="feed-sidebar col-sm-4">
+    <div class="feed-sidebar col-sm">
       <div class="group-about-me-panel sidebar-item">
         <h6 class="panel-heading">{{t "groups.activity.about" group=group.name}}</h6>
         <p>


### PR DESCRIPTION
The group sidebar was being pushed underneath the feed.

Changes proposed in this pull request:

- change column size

/cc @hummingbird-me
