### PR TITLE
Replace word-wrap hack with full browser support

### DIFF
--- a/app/styles/utilities/_mixins.scss
+++ b/app/styles/utilities/_mixins.scss
@@ -4,10 +4,7 @@
   transform: translateY(-50%);
 }
 
-@mixin word-break($break: '') {
-  @if $break == 'all' {
-    word-break: break-all;
-  }
-  word-wrap: break-word;
-  word-break: break-word;
+@mixin word-break() {
+  word-wrap: break-word; // Non-standard name for overflow-wrap (Edge)
+  overflow-wrap: word-break; 
 }

--- a/app/styles/utilities/_mixins.scss
+++ b/app/styles/utilities/_mixins.scss
@@ -6,5 +6,5 @@
 
 @mixin word-break() {
   word-wrap: break-word; // Non-standard name for overflow-wrap (Edge)
-  overflow-wrap: word-break; 
+  overflow-wrap: break-word; 
 }


### PR DESCRIPTION
Argument removed as was used for a single mixin call that no longer uses the argument.

`overflow-wrap`: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
Demo: https://jsfiddle.net/ofgd83um/78/

![](https://i.imgur.com/Bu1O2Og.png)

/cc @hummingbird-me/staff
