### PR TITLE
Admin Actions

### DIFF
--- a/app/components/users/ban-user.js
+++ b/app/components/users/ban-user.js
@@ -1,0 +1,21 @@
+import Component from '@ember/component';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { task } from 'ember-concurrency';
+
+export default Component.extend({
+  ajax: service(),
+  notify: service(),
+
+  banUser: task(function* () {
+    const userId = get(this, 'user.id');
+    yield get(this, 'ajax').request(`/users/${userId}/_ban`, { method: 'POST' });
+    get(this, 'notify').success('User was banned');
+  }).drop(),
+
+  actions: {
+    banUser() {
+      get(this, 'banUser').perform();
+    }
+  }
+});

--- a/app/components/users/delete-user-content.js
+++ b/app/components/users/delete-user-content.js
@@ -19,6 +19,7 @@ export default Component.extend({
       dataType: 'json',
       data: { kind }
     });
+    get(this, 'onClose')();
   }).drop(),
 
   actions: {

--- a/app/components/users/delete-user-content.js
+++ b/app/components/users/delete-user-content.js
@@ -1,0 +1,29 @@
+import Component from '@ember/component';
+import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { task } from 'ember-concurrency';
+
+export default Component.extend({
+  ajax: service(),
+  kinds: {
+    posts: false,
+    comments: false,
+    reactions: false
+  },
+
+  deleteContent: task(function* () {
+    const userId = get(this, 'user.id');
+    const kind = Object.keys(get(this, 'kinds')).filter(k => get(this, `kinds.${k}`));
+    yield get(this, 'ajax').request(`/users/${userId}/_nuke`, {
+      method: 'POST',
+      dataType: 'json',
+      data: { kind }
+    });
+  }).drop(),
+
+  actions: {
+    deleteContent() {
+      get(this, 'deleteContent').perform();
+    }
+  }
+});

--- a/app/components/users/view-alt-accounts.js
+++ b/app/components/users/view-alt-accounts.js
@@ -1,0 +1,20 @@
+import Component from '@ember/component';
+import { get, set } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { task } from 'ember-concurrency';
+
+export default Component.extend({
+  ajax: service(),
+  alts: [],
+
+  didReceiveAttrs() {
+    this._super(...arguments);
+    const userId = get(this, 'user.id');
+    get(this, 'loadAlts').perform(userId);
+  },
+
+  loadAlts: task(function* (userId) {
+    const alts = yield get(this, 'ajax').request(`/users/${userId}/_alts`);
+    set(this, 'alts', alts);
+  }).drop()
+});

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -7,6 +7,7 @@ import { image } from 'client/helpers/image';
 
 export default Controller.extend({
   isEditing: false,
+  isViewingPastNames: false,
   user: alias('model'),
 
   queryCache: service(),

--- a/app/templates/components/users/ban-user.hbs
+++ b/app/templates/components/users/ban-user.hbs
@@ -1,0 +1,4 @@
+{{modals/confirm-action
+  title="Are you sure you want to ban this user?"
+  text="They can access and update their library, but cannot make posts, comments, or reactions."
+  onConfirm=(action "banUser")}}

--- a/app/templates/components/users/delete-user-content.hbs
+++ b/app/templates/components/users/delete-user-content.hbs
@@ -1,0 +1,37 @@
+{{#bootstrap/bs-modal id=modalId onClose=onClose as |modal|}}
+  {{#modal.header}}
+    <h3 class="text-xs-center">
+      Delete Content by {{user.name}}
+    </h3>
+  {{/modal.header}}
+
+  {{#modal.body}}
+    <form>
+      <div class="form-group form-check">
+        <input type="checkbox" class="form-check-input" id="kind-posts"
+          onclick={{action (mut kinds.posts) value="target.checked"}} checked={{kinds.posts}}>
+        <label class="form-check-label" for="kind-posts">Posts</label>
+      </div>
+      <div class="form-group form-check">
+        <input type="checkbox" class="form-check-input" id="kind-comments"
+          onclick={{action (mut kinds.comments) value="target.checked"}} checked={{kinds.comments}}>
+        <label class="form-check-label" for="kind-comments">Comments</label>
+      </div>
+      <div class="form-group form-check">
+        <input type="checkbox" class="form-check-input" id="kind-reactions"
+          onclick={{action (mut kinds.reactions) value="target.checked"}} checked={{kinds.reactions}}>
+        <label class="form-check-label" for="kind-reactions">Reactions</label>
+      </div>
+    </form>
+  {{/modal.body}}
+
+  {{#modal.footer}}
+    {{#if deleteContent.isRunning}}
+      {{loading-spinner size="large"}}
+    {{else}}
+      <button class="button button--primary btn-lg btn-block" onclick={{action "deleteContent"}}>
+        Delete
+      </button>
+    {{/if}}
+  {{/modal.footer}}
+{{/bootstrap/bs-modal}}

--- a/app/templates/components/users/view-alt-accounts.hbs
+++ b/app/templates/components/users/view-alt-accounts.hbs
@@ -1,0 +1,26 @@
+{{#bootstrap/bs-modal id=modalId onClose=onClose as |modal|}}
+  {{#modal.header}}
+    <h3 class="text-xs-center">
+      Possible Alt Accounts of {{user.name}}
+    </h3>
+  {{/modal.header}}
+
+  {{#modal.body}}
+    {{#if loadAlts.isRunning}}
+      {{loading-spinner size="large"}}
+    {{else}}
+      <ul>
+        {{#each alts as |alt|}}
+          <li>
+            <a href={{href-to "users.index" alt.id}}>
+              {{alt.name}}
+            </a>
+            (Weight: {{decimal-number alt.weight}})
+          </li>
+        {{else}}
+          <li><i>No alts found</i></li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  {{/modal.body}}
+{{/bootstrap/bs-modal}}

--- a/app/templates/components/users/view-past-names.hbs
+++ b/app/templates/components/users/view-past-names.hbs
@@ -1,0 +1,17 @@
+{{#bootstrap/bs-modal id=modalId onClose=onClose as |modal|}}
+  {{#modal.header}}
+    <h3 class="text-xs-center">
+      Past Names
+    </h3>
+  {{/modal.header}}
+
+  {{#modal.body}}
+    <ul>
+      {{#each user.pastNames as |name|}}
+        <li>{{name}}</li>
+      {{else}}
+        <li><i>No previous names</i></li>
+      {{/each}}
+    </ul>
+  {{/modal.body}}
+{{/bootstrap/bs-modal}}

--- a/app/templates/users.hbs
+++ b/app/templates/users.hbs
@@ -69,9 +69,15 @@
                           modalId="delete-user-content-modal"
                           onClose=(toggle-action "isDeletingContent" this))}}
                       {{/if}}
-                      {{#dropdown.menu-item}}
+                      {{#dropdown.menu-item onClick=(action (toggle "isBanningUser" this))}}
                         Ban
                       {{/dropdown.menu-item}}
+                      {{#if isBanningUser}}
+                        {{to-elsewhere named="modal" send=(component "users/ban-user"
+                          user=user
+                          modalId="ban-user-modal"
+                          onClose=(toggle-action "isBanningUser" this))}}
+                      {{/if}}
                     {{/dropdown.menu}}
                   {{/bootstrap/bs-dropdown}}
                 {{/if}}

--- a/app/templates/users.hbs
+++ b/app/templates/users.hbs
@@ -60,9 +60,15 @@
                           modalId="view-alt-accounts-modal"
                           onClose=(toggle-action "isViewingAltAccounts" this))}}
                       {{/if}}
-                      {{#dropdown.menu-item}}
-                        Delete All Posts/Comments
+                      {{#dropdown.menu-item onClick=(action (toggle "isDeletingContent" this))}}
+                        Delete User-Created Content
                       {{/dropdown.menu-item}}
+                      {{#if isDeletingContent}}
+                        {{to-elsewhere named="modal" send=(component "users/delete-user-content"
+                          user=user
+                          modalId="delete-user-content-modal"
+                          onClose=(toggle-action "isDeletingContent" this))}}
+                      {{/if}}
                       {{#dropdown.menu-item}}
                         Ban
                       {{/dropdown.menu-item}}

--- a/app/templates/users.hbs
+++ b/app/templates/users.hbs
@@ -46,15 +46,20 @@
                         View Past Names
                       {{/dropdown.menu-item}}
                       {{#if isViewingPastNames}}
-                        TEST
                         {{to-elsewhere named="modal" send=(component "users/view-past-names"
                           user=user
                           modalId="view-past-names-modal"
                           onClose=(toggle-action "isViewingPastNames" this))}}
                       {{/if}}
-                      {{#dropdown.menu-item}}
+                      {{#dropdown.menu-item onClick=(action (toggle "isViewingAltAccounts" this))}}
                         View Alt Accounts
                       {{/dropdown.menu-item}}
+                      {{#if isViewingAltAccounts}}
+                        {{to-elsewhere named="modal" send=(component "users/view-alt-accounts"
+                          user=user
+                          modalId="view-alt-accounts-modal"
+                          onClose=(toggle-action "isViewingAltAccounts" this))}}
+                      {{/if}}
                       {{#dropdown.menu-item}}
                         Delete All Posts/Comments
                       {{/dropdown.menu-item}}

--- a/app/templates/users.hbs
+++ b/app/templates/users.hbs
@@ -37,21 +37,32 @@
 
                 {{! admin actions }}
                 {{#if (can "view admin" user)}}
-                  {{! Previous names }}
-                  {{#unless (is-empty user.pastNames)}}
-                    {{#bootstrap/bs-dropdown class="d-inline" as |dropdown|}}
-                      {{#dropdown.button class="button button--light-outline"}}
-                        Previous Names
-                      {{/dropdown.button}}
-                      {{#dropdown.menu}}
-                        {{#each user.pastNames as |name|}}
-                          {{#dropdown.menu-item}}
-                            {{name}}
-                          {{/dropdown.menu-item}}
-                        {{/each}}
-                      {{/dropdown.menu}}
-                    {{/bootstrap/bs-dropdown}}
-                  {{/unless}}
+                  {{#bootstrap/bs-dropdown class="d-inline" as |dropdown|}}
+                    {{#dropdown.button class="button button--light-outline"}}
+                      Admin
+                    {{/dropdown.button}}
+                    {{#dropdown.menu}}
+                      {{#dropdown.menu-item onClick=(action (toggle "isViewingPastNames" this))}}
+                        View Past Names
+                      {{/dropdown.menu-item}}
+                      {{#if isViewingPastNames}}
+                        TEST
+                        {{to-elsewhere named="modal" send=(component "users/view-past-names"
+                          user=user
+                          modalId="view-past-names-modal"
+                          onClose=(toggle-action "isViewingPastNames" this))}}
+                      {{/if}}
+                      {{#dropdown.menu-item}}
+                        View Alt Accounts
+                      {{/dropdown.menu-item}}
+                      {{#dropdown.menu-item}}
+                        Delete All Posts/Comments
+                      {{/dropdown.menu-item}}
+                      {{#dropdown.menu-item}}
+                        Ban
+                      {{/dropdown.menu-item}}
+                    {{/dropdown.menu}}
+                  {{/bootstrap/bs-dropdown}}
                 {{/if}}
               </div>
             </div>


### PR DESCRIPTION
So this is kinda janky but everything seems to work fine.  Basically, this provides a set of admin actions exposed to moderators on a user's profile, including:

 * Finding alt accounts
 * Banning
 * Deleting UGC
 * Viewing past names

Everything's kinda crammed into modals and the interface is horrible but it's a huge improvement over the current stuff.

It's messy but I'm figuring it probably doesn't matter because I bet we're gonna redo it in v4 since it'll be moved to GraphQL anyways