### PR TITLE
Fix space between blocks on the registration form

### DIFF
--- a/app/styles/layout/_modals.scss
+++ b/app/styles/layout/_modals.scss
@@ -164,6 +164,11 @@
   }
   .modal-wrapper {
     padding: 30px;
+    
+    form {
+      display: grid;
+      grid-gap: 45px;
+    }
   }
   @media (min-width: 544px) {
     .modal-dialog {


### PR DESCRIPTION
Changes proposed in this pull request:

Added space between blocks on the registration form

Before:
[imgur](https://i.imgur.com/X0gLiN8.png)

After:
[imgur](https://i.imgur.com/HIHWGi7.png)
