### PR TITLE
 Added bottom spacing for the registration form sections

### DIFF
--- a/app/styles/layout/_modals.scss
+++ b/app/styles/layout/_modals.scss
@@ -164,6 +164,11 @@
   }
   .modal-wrapper {
     padding: 30px;
+    
+    form {
+      display: grid;
+      grid-gap: 45px;
+    }
   }
   @media (min-width: 544px) {
     .modal-dialog {

--- a/app/styles/layout/_modals.scss
+++ b/app/styles/layout/_modals.scss
@@ -165,9 +165,8 @@
   .modal-wrapper {
     padding: 30px;
     
-    form {
-      display: grid;
-      grid-gap: 45px;
+    .auth-section {
+      margin-bottom: 45px;
     }
   }
   @media (min-width: 544px) {


### PR DESCRIPTION
Added margin-bottom for each input item on registration form.
Now hints do not overlap with the next block headers.