### PR TITLE
Prevent autocomplete in comment replies

### DIFF
--- a/app/templates/components/stream-feed/items/post/comment-box.hbs
+++ b/app/templates/components/stream-feed/items/post/comment-box.hbs
@@ -10,7 +10,7 @@
         (if dropzone.valid (t "feeds.uploads.drop") (t "feeds.uploads.invalid"))
         (if queue.files.length (t "feeds.uploads.uploading" number=queue.files.length progress=queue.progress) placeholder))
       class=className
-      autocomplete="new-password"
+      autocomplete="reply"
     }}
 
     {{#unless (or upload embedUrl)}}

--- a/app/templates/components/stream-feed/items/post/comment-box.hbs
+++ b/app/templates/components/stream-feed/items/post/comment-box.hbs
@@ -10,6 +10,7 @@
         (if dropzone.valid (t "feeds.uploads.drop") (t "feeds.uploads.invalid"))
         (if queue.files.length (t "feeds.uploads.uploading" number=queue.files.length progress=queue.progress) placeholder))
       class=className
+      autocomplete="new-password"
     }}
 
     {{#unless (or upload embedUrl)}}


### PR DESCRIPTION
I can only reproduce the autocomplete on `*.kitsu.io`. Setting `autocomplete="off"` doesn't fix it, so all I can think of to do is this hack.

This issue might be relevant, but browsers shouldnt autocomplete elements that aren't in forms anyway, so I'm not sure what gives.

https://bugs.chromium.org/p/chromium/issues/detail?id=587466