### PR TITLE
Fixed API url on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [meta]:https://github.com/hummingbird-me/hummingbird
 [server]:https://github.com/hummingbird-me/hummingbird-server
-[api docs]:https://github.com/hummingbird-me/hummingbird-client
+[api docs]:https://github.com/hummingbird-me/api-docs
 
 ---
 


### PR DESCRIPTION
Changed the API url on README to point to correct API repository
