### PR TITLE
Add more title localisations

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -235,15 +235,19 @@ media:
       titles:
         header: "Alternative Titles"
         en: "English"
-        en_us: "English"
+        en_us: "English (US)"
         en_jp: "Romanized"
         ja_jp: "Japanese"
-        en_cn: "Romanized"
+        en_cn: "Pinyin"
         zh_cn: "Chinese"
-        en_th: "Romanized"
+        en_th: "Romanized Thai"
         th_th: "Thai"
-        en_kr: "Romanized"
+        en_kr: "Romanized Korean"
         ko_kr: "Korean"
+        fr_fr: "French"
+        ru_ru: "Russian"
+        vi_vi: "Vietnamese"
+        ar_ar: "Arabic"
         synonyms: "Synonyms"
       information:
         header: "{type, select,


### PR DESCRIPTION
Mirrors https://github.com/hummingbird-me/kitsu-strings/pull/1

1. Named the romanisation locales as Korean/Chinese shows end up being a huge list of "Romanized" between English and the Korean/Chinese/Japanese titles

2. There are a lot of French anime-inspired shows where their original titles are stuck in the Synonyms (or missing completely)

3. Most manga have Russian, Vietnamese and Arabic titles on MangaUpdates (and MangaDex). Most latin based languages tend to use the romanised title

/cc @hummingbird-me/staff
