### PR TITLE
ci: fix google chrome stable installation by using the chrome addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
+os: linux
 language: node_js
 node_js: 10
 
-sudo: false
 dist: trusty
 
 addons:
@@ -39,7 +39,6 @@ cache:
 
 deploy:
   provider: script
-  skip_cleanup: true
   script: ember deploy production
   on:
     branch: the-future

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,7 @@ sudo: false
 dist: trusty
 
 addons:
-  apt:
-    sources:
-    - google-chrome
-    packages:
-    - google-chrome-stable
+  chrome: stable
   code_climate:
     repo_token: f15069c85832661086a0f758b25cf410e58ae1f80dbcbc762021dfc71feb8f71
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove APT source for Google Chrome Stable
- Add Chrome addon set to `stable`
