### PR TITLE
Report route name as page title

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -36,7 +36,7 @@ const RouterInstance = Router.extend(RouterScroll, Breadcrumbs, {
   _trackPage() {
     scheduleOnce('afterRender', () => {
       const page = get(this, 'url');
-      const title = get(this, 'head.title') || get(this, 'currentRouteName');
+      const title = get(this, 'currentRouteName') || get(this, 'head.title');
       get(this, 'metrics').trackPage({ page, title });
     });
   },


### PR DESCRIPTION
Report the routeName as the page title so we can track users by route, so we can see things like "how many users are browsing anime pages", etc.