### PR TITLE
feat: compute independent min years for anime & manga explore

### DIFF
--- a/app/controllers/anime/index.js
+++ b/app/controllers/anime/index.js
@@ -1,6 +1,9 @@
 import MediaIndexController, { MEDIA_QUERY_PARAMS } from 'client/controllers/media/index';
 import QueryParams from 'ember-parachute';
+import { isEmpty } from '@ember/utils';
 import { serializeArray, deserializeArray } from 'client/utils/queryable';
+import { moment } from 'client/utils/moment';
+import { minYearAnime } from 'client/utils/media-minyear';
 
 const queryParams = new QueryParams(MEDIA_QUERY_PARAMS, {
   ageRating: {
@@ -31,6 +34,26 @@ const queryParams = new QueryParams(MEDIA_QUERY_PARAMS, {
     },
     deserialize(value = []) {
       return deserializeArray(value);
+    }
+  },
+  year: {
+    defaultValue: [minYearAnime, moment().year() + 2],
+    refresh: true,
+    serialize(value) {
+      const [lower, upper] = value;
+      if (lower === minYearAnime && upper === (moment().year() + 2)) {
+        return undefined;
+      } if (upper === (moment().year() + 2)) {
+        return serializeArray([lower, null]);
+      }
+      return serializeArray(value);
+    },
+    deserialize(value = []) {
+      const [lower, upper] = deserializeArray(value);
+      if (isEmpty(upper)) {
+        return [lower, moment().year() + 2];
+      }
+      return [lower, upper];
     }
   }
 });

--- a/app/controllers/manga/index.js
+++ b/app/controllers/manga/index.js
@@ -1,7 +1,32 @@
 import MediaIndexController, { MEDIA_QUERY_PARAMS } from 'client/controllers/media/index';
 import QueryParams from 'ember-parachute';
+import { isEmpty } from '@ember/utils';
+import { serializeArray, deserializeArray } from 'client/utils/queryable';
+import { moment } from 'client/utils/moment';
+import { minYearManga } from 'client/utils/media-minyear';
 
-const queryParams = new QueryParams(MEDIA_QUERY_PARAMS);
+const queryParams = new QueryParams(MEDIA_QUERY_PARAMS, {
+  year: {
+    defaultValue: [minYearManga, moment().year() + 2],
+    refresh: true,
+    serialize(value) {
+      const [lower, upper] = value;
+      if (lower === minYearManga && upper === (moment().year() + 2)) {
+        return undefined;
+      } if (upper === (moment().year() + 2)) {
+        return serializeArray([lower, null]);
+      }
+      return serializeArray(value);
+    },
+    deserialize(value = []) {
+      const [lower, upper] = deserializeArray(value);
+      if (isEmpty(upper)) {
+        return [lower, moment().year() + 2];
+      }
+      return [lower, upper];
+    }
+  }
+});
 
 export default MediaIndexController.extend(queryParams.Mixin, {
   mediaType: 'manga',

--- a/app/controllers/media/index.js
+++ b/app/controllers/media/index.js
@@ -3,6 +3,7 @@ import { get, set } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { moment } from 'client/utils/moment';
 import { concat } from 'client/utils/computed-macros';
+import { minYearAnime, minYearManga } from 'client/utils/media-minyear';
 import { serializeArray, deserializeArray } from 'client/utils/queryable';
 
 export const MEDIA_QUERY_PARAMS = {
@@ -77,26 +78,6 @@ export const MEDIA_QUERY_PARAMS = {
       }
       return [lower, upper];
     }
-  },
-  year: {
-    defaultValue: [1868, moment().year() + 2],
-    refresh: true,
-    serialize(value) {
-      const [lower, upper] = value;
-      if (lower === 1868 && upper === (moment().year() + 2)) {
-        return undefined;
-      } if (upper === (moment().year() + 2)) {
-        return serializeArray([lower, null]);
-      }
-      return serializeArray(value);
-    },
-    deserialize(value = []) {
-      const [lower, upper] = deserializeArray(value);
-      if (isEmpty(upper)) {
-        return [lower, moment().year() + 2];
-      }
-      return [lower, upper];
-    }
   }
 };
 
@@ -106,10 +87,11 @@ export default Controller.extend({
 
   init() {
     this._super(...arguments);
-    set(this, 'maxYear', moment().year() + 2);
     const mediaType = get(this, 'mediaType');
     set(this, 'isAnime', mediaType === 'anime');
     set(this, 'isManga', mediaType === 'manga');
+    set(this, 'minYear', get(this, 'isAnime') ? minYearAnime : minYearManga);
+    set(this, 'maxYear', moment().year() + 2);
   },
 
   actions: {

--- a/app/templates/media/index.hbs
+++ b/app/templates/media/index.hbs
@@ -22,7 +22,7 @@
             <div class="filter-slider--wrapper">
               {{range-slider
                 class="slider"
-                min=1868
+                min=minYear
                 max=maxYear
                 start=year
                 step=1
@@ -33,7 +33,7 @@
               }}
             </div>
             <div class="filter-legend">
-              <div class="low-value">1868</div>
+              <div class="low-value">{{minYear}}</div>
               <div class="high-value">∞</div>
             </div>
           </div>

--- a/app/utils/media-minyear.js
+++ b/app/utils/media-minyear.js
@@ -1,0 +1,2 @@
+export const minYearAnime = 1907;
+export const minYearManga = 1862;


### PR DESCRIPTION
Earliest anime is 1907 and earliest manga is 1862. Using 1862 on anime too makes the usable portion of the slider (1907->present+2) much smaller than it needs to be

Additionally moves the years to one source of truth instead of split between the controller and template.

Unfortunately leads to duplicated `year` QUERY_PARAM due to the needed `get` object not being accessible from the media controller outside of the exported class and no other way of checking if it's an anime or manga media type.