### PR TITLE
QoL changes for mobile + modernising CSS

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="keywords" content="anime, manga, kitsu, hummingbird, anime news">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
     <meta name="google-site-verification" content="YKitj6wgNvrB_gq_M8vbT0JmLHEONWRZN29H96TROf0">
     <meta http-equiv="Accept-CH" content="DPR, Width, Viewport-Width">
 

--- a/app/styles/base/_shame.scss
+++ b/app/styles/base/_shame.scss
@@ -24,24 +24,6 @@ body {
   }
 }
 
-// Running into an issue where I'm unable to align the edge of the absolutely positioned
-// .cover-user-info area to 'right: 0', this hacky solution instead sets the max-width
-// to match that of the container. More elegant solution is needed.
-.cover-user-info {
-  @media (min-width: 544px) {
-    max-width: 576px;
-  }
-  @media (min-width: 768px) {
-    max-width: 720px;
-  }
-  @media (min-width: 992px) {
-    max-width: 940px;
-  }
-  @media (min-width: 1200px) {
-    max-width: 1140px;
-  }
-}
-
 // No idea why, but the library content width for some reason isn't getting set.
 // A fix for this issue would be great.
 .container {

--- a/app/styles/layout/_cover-images.scss
+++ b/app/styles/layout/_cover-images.scss
@@ -107,6 +107,10 @@
   position: relative;
   display: grid;
   grid-template-columns: minmax(50px, 1fr) minmax(auto, 1150px) minmax(50px, 1fr);
+  @media (max-width: 575px) {
+    grid-template-columns: minmax(10px, 1fr) minmax(auto, 1150px) minmax(10px, 1fr);
+  }
+
 
   .cover-photo {
     background-size: cover;

--- a/app/styles/layout/_cover-images.scss
+++ b/app/styles/layout/_cover-images.scss
@@ -105,6 +105,9 @@
   height: 400px;
   width: 100%;
   position: relative;
+  display: grid;
+  grid-template-columns: minmax(50px, 1fr) minmax(auto, 1150px) minmax(50px, 1fr);
+
   .cover-photo {
     background-size: cover;
     background-repeat: no-repeat;
@@ -112,20 +115,33 @@
     height: 400px;
     width: 100%;
     position: relative;
+    grid-column-start: 1;
+    grid-column-end: 4;
   }
   .cover-user-info {
+    grid-column-start: 2;
+    grid-column-end: 3;
     position: absolute;
     width: 100%;
     bottom: 30px;
     z-index: $zIndex--cover-user-info;
-    display: grid;
-    gap: 10px;
+    display: inline-grid;
+    row-gap: 10px;
+    column-gap: 50px;
     grid-template-rows: auto auto;
+    grid-template-columns: auto;
+
+    @media (min-width: 993px) {
+      grid-template-rows: auto;
+      grid-template-columns: auto 1fr;
+    }
+
     &.cover-media-info {
       bottom: 15px;
     }
   }
   .primary-info {
+    grid-column-end: 2;
     display: grid;
     grid-template-columns: minmax(min-content, auto) 1fr;
     gap: 25px;
@@ -135,7 +151,7 @@
 
     @media (max-width: 300px) {
       grid-template-columns: auto;
-      grid-template-rows: auto, auto;
+      grid-template-rows: auto auto;
     }
 
     @media (max-width: 575px) {
@@ -193,8 +209,12 @@
     }
   }
   .cover-profiles {
-    z-index: $zIndex-3;
+    z-index: $zIndex-6;
     grid-row-start: 2;
+    @media (min-width: 993px) {
+      grid-column-start: 2;
+      grid-column-end: 3;
+    }
     position: absolute;
     right: 0;
     bottom: 0;

--- a/app/styles/layout/_cover-images.scss
+++ b/app/styles/layout/_cover-images.scss
@@ -118,30 +118,38 @@
     width: 100%;
     bottom: 30px;
     z-index: $zIndex--cover-user-info;
+    display: grid;
+    gap: 10px;
+    grid-template-rows: auto auto;
     &.cover-media-info {
       bottom: 15px;
     }
   }
   .primary-info {
-    float: left;
-    height: 100px;
+    display: grid;
+    grid-template-columns: minmax(min-content, auto) 1fr;
+    gap: 25px;
+    z-index: $zIndex-7;
+    grid-row-start: 1;
+    grid-row-end: 1;
+
+    @media (max-width: 300px) {
+      grid-template-columns: auto;
+      grid-template-rows: auto, auto;
+    }
+
     @media (max-width: 575px) {
-      padding: 0 20px;
+      padding: 0 10px;
     }
     @media (max-width: 992px) {
       width: 100%;
-      float: initial;
-      margin-bottom: 15px;
     }
-  }
-  .cover-avatar {
-    float: left;
   }
   .cover-username {
     color: $white;
     font-size: 30px;
     font-weight: 500;
-    margin-top: 5px;
+    margin-top: 10px;
     margin-bottom: 10px;
     .tag {
       position: relative;
@@ -164,11 +172,7 @@
   .mini-bio {
     color: $white;
     font-size: 14px;
-    float: left;
-    margin-left: 25px;
     position: relative;
-    top: 50%;
-    transform: translateY(-50%);
     p {
       margin-bottom: 0;
     }
@@ -189,6 +193,8 @@
     }
   }
   .cover-profiles {
+    z-index: $zIndex-3;
+    grid-row-start: 2;
     position: absolute;
     right: 0;
     bottom: 0;

--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -252,6 +252,12 @@
   position: relative;
   z-index: $zIndex--stream-item-block;
 
+  .author-name {
+    display: inline-block;
+    font-size: 16px;
+    font-family: $heading-font-family;
+    font-weight: 700;
+  }
   .author-avatar {
     float: left;
     margin-right: 15px;
@@ -554,13 +560,11 @@
     border-radius: 999em;
   }
   .media-heading {
-    font-size: 14px;
-    margin-bottom: 0;
-    display: inline;
-    float: left;
+    font-size: 15px;
+    margin-bottom: 5px;
+    display: block;
     position: relative;
     top: 3px;
-    margin-right: 5px;
   }
   .media-body {
     font-size: 14px;

--- a/app/styles/layout/_navbar.scss
+++ b/app/styles/layout/_navbar.scss
@@ -266,7 +266,7 @@
 
 .search--drop {
   width: 350px;
-  max-height: 90vh;
+  max-height: 80vh;
   background-color: #fff;
   overflow: auto;
   border-radius: 3px;

--- a/app/templates/users.hbs
+++ b/app/templates/users.hbs
@@ -1,99 +1,95 @@
 {{! @TODO: Componentize }}
 <div class="user-cover no-edit">
-  <div class="cover-photo" style={{coverImageStyle}}>
-    <div class="container">
-      <div class="row">
-        <div class="cover-user-info">
-          <div class="primary-info">
-            <div class="cover-avatar avatar">
-              <img src={{image user.avatar "large"}} class="avatar-image avatar-image--large">
-            </div>
-            <div class="mini-bio">
-              <h3 class="cover-username" data-test-username>
-                {{user.name}}
-                {{user-badge user}}
-              </h3>
-              <div class="cover-cta">
-                {{#if (not (is-self user))}}
-                  {{follow-button user=user relationship=follow loading=fetchFollowTask.isRunning}}
-                {{/if}}
+  <div class="cover-user-info">
+    <div class="primary-info">
+      <div class="cover-avatar avatar">
+        <img src={{image user.avatar "large"}} class="avatar-image avatar-image--large">
+      </div>
+      <div class="mini-bio">
+        <h3 class="cover-username" data-test-username>
+          {{user.name}}
+          {{user-badge user}}
+        </h3>
+        <div class="cover-cta">
+          {{#if (not (is-self user))}}
+            {{follow-button user=user relationship=follow loading=fetchFollowTask.isRunning}}
+          {{/if}}
 
-                {{! edit button }}
-                {{#if (can "edit user" user)}}
-                  <button class="button button--light-outline" onclick={{action (toggle "isEditing" this)}}>
-                    <span class="button-label button-defaultState">{{t "users.profile.edit"}}</span>
-                  </button>
-                  {{#if isEditing}}
-                    {{to-elsewhere named="modal" send=(component "users/edit-profile"
-                      user=user
-                      modalId="edit-profile-modal"
-                      onClose=(toggle-action "isEditing" this))}}
-                  {{/if}}
-                {{/if}}
+          {{! edit button }}
+          {{#if (can "edit user" user)}}
+            <button class="button button--light-outline" onclick={{action (toggle "isEditing" this)}}>
+              <span class="button-label button-defaultState">{{t "users.profile.edit"}}</span>
+            </button>
+            {{#if isEditing}}
+              {{to-elsewhere named="modal" send=(component "users/edit-profile"
+                user=user
+                modalId="edit-profile-modal"
+                onClose=(toggle-action "isEditing" this))}}
+            {{/if}}
+          {{/if}}
 
-                {{#if (or follow (and session.hasUser (not (is-self user))))}}
-                  {{users/user-actions user=user follow=follow}}
-                {{/if}}
+          {{#if (or follow (and session.hasUser (not (is-self user))))}}
+            {{users/user-actions user=user follow=follow}}
+          {{/if}}
 
-                {{! admin actions }}
-                {{#if (can "view admin" user)}}
-                  {{#bootstrap/bs-dropdown class="d-inline" as |dropdown|}}
-                    {{#dropdown.button class="button--light-outline button--outline"}}
-                      {{t "users.admin.button"}}
-                    {{/dropdown.button}}
-                    {{#dropdown.menu}}
-                      {{#dropdown.menu-item onClick=(action (toggle "isViewingPastNames" this))}}
-                        {{t "users.admin.past-names"}}
-                      {{/dropdown.menu-item}}
-                      {{#if isViewingPastNames}}
-                        {{to-elsewhere named="modal" send=(component "users/view-past-names"
-                          user=user
-                          modalId="view-past-names-modal"
-                          onClose=(toggle-action "isViewingPastNames" this))}}
-                      {{/if}}
-                      {{#dropdown.menu-item onClick=(action (toggle "isViewingAltAccounts" this))}}
-                        {{t "users.admin.alt-accounts"}}
-                      {{/dropdown.menu-item}}
-                      {{#if isViewingAltAccounts}}
-                        {{to-elsewhere named="modal" send=(component "users/view-alt-accounts"
-                          user=user
-                          modalId="view-alt-accounts-modal"
-                          onClose=(toggle-action "isViewingAltAccounts" this))}}
-                      {{/if}}
-                      {{#dropdown.menu-item onClick=(action (toggle "isDeletingContent" this))}}
-                        {{t "users.admin.delete-content"}}
-                      {{/dropdown.menu-item}}
-                      {{#if isDeletingContent}}
-                        {{to-elsewhere named="modal" send=(component "users/delete-user-content"
-                          user=user
-                          modalId="delete-user-content-modal"
-                          onClose=(toggle-action "isDeletingContent" this))}}
-                      {{/if}}
-                      {{#dropdown.menu-item onClick=(action (toggle "isBanningUser" this))}}
-                        {{t "users.admin.ban"}}
-                      {{/dropdown.menu-item}}
-                      {{#if isBanningUser}}
-                        {{to-elsewhere named="modal" send=(component "users/ban-user"
-                          user=user
-                          modalId="ban-user-modal"
-                          onClose=(toggle-action "isBanningUser" this))}}
-                      {{/if}}
-                    {{/dropdown.menu}}
-                  {{/bootstrap/bs-dropdown}}
+          {{! admin actions }}
+          {{#if (can "view admin" user)}}
+            {{#bootstrap/bs-dropdown class="d-inline" as |dropdown|}}
+              {{#dropdown.button class="button--light-outline button--outline"}}
+                {{t "users.admin.button"}}
+              {{/dropdown.button}}
+              {{#dropdown.menu}}
+                {{#dropdown.menu-item onClick=(action (toggle "isViewingPastNames" this))}}
+                  {{t "users.admin.past-names"}}
+                {{/dropdown.menu-item}}
+                {{#if isViewingPastNames}}
+                  {{to-elsewhere named="modal" send=(component "users/view-past-names"
+                    user=user
+                    modalId="view-past-names-modal"
+                    onClose=(toggle-action "isViewingPastNames" this))}}
                 {{/if}}
-              </div>
-            </div>
-          </div>
-
-          {{! profile link badges }}
-          <div class="cover-profiles">
-            <div class="about-me-profiles">
-              {{users/profile-links user=user}}
-            </div>
-          </div>
+                {{#dropdown.menu-item onClick=(action (toggle "isViewingAltAccounts" this))}}
+                  {{t "users.admin.alt-accounts"}}
+                {{/dropdown.menu-item}}
+                {{#if isViewingAltAccounts}}
+                  {{to-elsewhere named="modal" send=(component "users/view-alt-accounts"
+                    user=user
+                    modalId="view-alt-accounts-modal"
+                    onClose=(toggle-action "isViewingAltAccounts" this))}}
+                {{/if}}
+                {{#dropdown.menu-item onClick=(action (toggle "isDeletingContent" this))}}
+                  {{t "users.admin.delete-content"}}
+                {{/dropdown.menu-item}}
+                {{#if isDeletingContent}}
+                  {{to-elsewhere named="modal" send=(component "users/delete-user-content"
+                    user=user
+                    modalId="delete-user-content-modal"
+                    onClose=(toggle-action "isDeletingContent" this))}}
+                {{/if}}
+                {{#dropdown.menu-item onClick=(action (toggle "isBanningUser" this))}}
+                  {{t "users.admin.ban"}}
+                {{/dropdown.menu-item}}
+                {{#if isBanningUser}}
+                  {{to-elsewhere named="modal" send=(component "users/ban-user"
+                    user=user
+                    modalId="ban-user-modal"
+                    onClose=(toggle-action "isBanningUser" this))}}
+                {{/if}}
+              {{/dropdown.menu}}
+            {{/bootstrap/bs-dropdown}}
+          {{/if}}
         </div>
       </div>
     </div>
+
+    {{! profile link badges }}
+    <div class="cover-profiles">
+      <div class="about-me-profiles">
+        {{users/profile-links user=user}}
+      </div>
+    </div>
+  </div>
+  <div class="cover-photo" style={{coverImageStyle}}>
     <div class="dark-cover-overlay"></div>
   </div>
 </div>


### PR DESCRIPTION
Changes proposed in this pull request:

Change viewport meta to not allow zooming. This is so that it'll act more like an actual app and not auto-zoom when you press the search bar or attempt to write a comment. It actually still allow you to zoom but doesn't auto-zoom on iOS when you press an input box

Switched the cover-user stuff to CSS Grid instead of floats
Switched the whole profile cover to use CSS Grid instead of Bootstrap

Current:
![](https://i.imgur.com/9IKTsoP.png)

Proposed change:
![](https://i.imgur.com/un9m6kn.png)

Made the max-height of the search-results slightly shorter so that you can access the lowest result on smaller devices that have browsers with UI elements at the bottom.
Current:
![](https://i.imgur.com/7RhqBeg.png)

Proposed change:
![](https://i.imgur.com/6Cw77lW.png)

Moved comments content below the usernames. This fixes the issue with the previous zalgo prevention fix and just makes more sense visually.
Current:
![](https://i.imgur.com/oBjPn5P.png)

Proposed change:
![](https://i.imgur.com/SbZ4ds2.png)

/cc @hummingbird-me/staff