### PR TITLE
Slugs or IDs on posts and comments

### DIFF
--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -252,6 +252,22 @@
   position: relative;
   z-index: $zIndex--stream-item-block;
 
+  .author-name {
+    display: inline-block;
+    font-size: 16px;
+    font-family: $heading-font-family;
+    font-weight: 700;
+  }
+  .author-slug, .author-id {
+    display: inline-block;
+    font-size: 12px;
+    font-family: $heading-font-family;
+    color: transparentize(desaturate($body-link-color, 5), 0.2);
+    font-weight: 500;
+    &:hover {
+      color: $body-link-color;
+    }
+  }
   .author-avatar {
     float: left;
     margin-right: 15px;
@@ -565,6 +581,16 @@
   .media-body {
     font-size: 14px;
     max-width: calc(100% - 45px);
+    .commenter-slug, .commenter-id {
+      display: inline-block;
+      font-size: 12px;
+      font-family: $heading-font-family;
+      color: transparentize(desaturate($body-link-color, 5), 0.2);
+      font-weight: 500;
+      &:hover {
+        color: $body-link-color;
+      }
+    }
     .comment-body {
       @include word-break();
       margin-bottom: 0;

--- a/app/templates/components/stream-feed/items/post.hbs
+++ b/app/templates/components/stream-feed/items/post.hbs
@@ -46,6 +46,15 @@
         <a class="author-name" href={{href-to "users.index" post.user}} onclick={{action "trackEngagement" "click"}}>
           {{post.user.name}}
         </a>
+        {{#if post.user.slug}}
+          <a class="author-slug" href={{href-to "users.index" post.user}}>
+            @{{post.user.slug}}
+          </a>
+        {{else}}
+          <a class="author-id" href={{href-to "users.index" post.user}}>
+              @{{post.user.id}}
+          </a>
+      {{/if}}
         {{user-badge post.user}}
 
         {{#if post.targetUser}}

--- a/app/templates/components/stream-feed/items/post/comment.hbs
+++ b/app/templates/components/stream-feed/items/post/comment.hbs
@@ -19,6 +19,15 @@
       <a href={{href-to "users.index" comment.user}}>
         {{comment.user.name}}
       </a>
+      {{#if comment.user.slug}}
+      <a class="commenter-slug" href={{href-to "users.index" comment.user}}>
+          @{{comment.user.slug}}
+      </a>
+      {{else}}
+      <a class="commenter-slug" href={{href-to "users.index" comment.user}}>
+          @{{comment.user.id}}
+      </a>
+      {{/if}}
     </h4>
 
     {{! comment content }}


### PR DESCRIPTION
Changes proposed in this pull request:

Added a twitter-like @ slug or @ id for posts to make it clearer how to mention users.

Add slugs next to usernames in posts and comments to make it easier to figure out how to mention them. Uses IDs if the user hasn't set any slug.

(Should merge the previous [pull request](https://github.com/hummingbird-me/kitsu-web/pull/1135) I made before this one as that one [fixes a bug](https://github.com/hummingbird-me/kitsu-web/pull/1135/commits/fe5834de9082115450fe1e6b07653eb609e5de20) which might cause problems with this request)

Image of the proposed change
![](https://cdn.discordapp.com/attachments/778684673161297940/789604411151614002/unknown.png)

/cc @hummingbird-me/staff
