### PR TITLE
Enable dark theme setting for any user

### DIFF
--- a/app/templates/settings/index.hbs
+++ b/app/templates/settings/index.hbs
@@ -86,6 +86,7 @@
         }}
           {{theme.text}}
         {{/power-select}}
+        <small>The dark theme is currently in open beta.</small>
       </div>
     </div>
 

--- a/app/templates/settings/index.hbs
+++ b/app/templates/settings/index.hbs
@@ -74,22 +74,20 @@
   </div>
   <div class="container">
     {{! themes }}
-    {{#if (has-feature "dark_theme")}}
-      <div class="form-group row">
-        <label class="col-xs-4 col-form-label">{{t "settings.index.theme"}}</label>
-        <div class="col-xs-8">
-          {{#power-select
-            renderInPlace=true
-            options=themes
-            selected=selectedTheme
-            searchEnabled=false
-            onchange=(action "changeTheme") as |theme|
-          }}
-            {{theme.text}}
-          {{/power-select}}
-        </div>
+    <div class="form-group row">
+      <label class="col-xs-4 col-form-label">{{t "settings.index.theme"}}</label>
+      <div class="col-xs-8">
+        {{#power-select
+          renderInPlace=true
+          options=themes
+          selected=selectedTheme
+          searchEnabled=false
+          onchange=(action "changeTheme") as |theme|
+        }}
+          {{theme.text}}
+        {{/power-select}}
       </div>
-    {{/if}}
+    </div>
 
 
     {{! country }}


### PR DESCRIPTION
Removed check for whether the user has the feature "dark_theme". Lets any user enable it in the settings. The second commit added a notice that the dark theme is in open beta.