### PR TITLE
Gave posts slightly rounded corners

### DIFF
--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -252,6 +252,7 @@
   background: $foreground-background-color;
   position: relative;
   z-index: $zIndex--stream-item-block;
+  border-radius: 3px 3px 0 0;
 
   .author-avatar {
     float: left;
@@ -540,6 +541,7 @@
 }
 
 .stream-item-comments {
+  border-radius: 0 0 3px 3px;
   background: darken($foreground-background-color, 2);
   @if $theme == "kitsu-dark" {
     background: darken($foreground-background-color, 4);


### PR DESCRIPTION
This fits the overall design language and I believe this was the original intent as .stream-item (the post parent div) already had this but the header and comment-bar at the bottom overrided this.

How my change makes it look (these corners were completely straight previously)
![image](https://user-images.githubusercontent.com/16106839/114314498-416c0880-9afb-11eb-8383-7fe22dd4eab1.png)

The reason why I believe it was the intent is that this is how it originally looks. Only some corners are missing the rounded edges.
![image](https://user-images.githubusercontent.com/16106839/114314502-45982600-9afb-11eb-9f20-50ac6f2df05b.png)
