### PR TITLE
Moved comment body below commenter displayname

### DIFF
--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -571,12 +571,10 @@
   }
   .media-heading {
     font-size: 14px;
-    margin-bottom: 0;
-    display: inline;
-    float: left;
+    margin-bottom: 5px;
+    display: block;
     position: relative;
     top: 3px;
-    margin-right: 5px;
   }
   .media-body {
     font-size: 14px;


### PR DESCRIPTION
This follows the same design trends as the Kitsu app, Facebook, YouTube, Reddit, and other large services. It also prevents the visual bug that the previous zalgo fix caused, but without the need to remove that fix.

Changed
![changed](https://user-images.githubusercontent.com/16106839/114930635-8793d580-9e35-11eb-881d-5f1fc687c3ef.png)

Old
![old](https://user-images.githubusercontent.com/16106839/114930568-72b74200-9e35-11eb-880b-c863d08a98a7.png)

Mobile
![image](https://user-images.githubusercontent.com/16106839/114931255-4b14a980-9e36-11eb-8924-3dab8f757fa3.png)