### PR TITLE
Fix horisontal overflow

### DIFF
--- a/app/styles/base/_shame.scss
+++ b/app/styles/base/_shame.scss
@@ -66,9 +66,14 @@ body {
   .settings--header {
     margin-top: 0;
   }
-  .feed-container {
-    overflow-y: hidden;
+  .stream-item-comments {
+    overflow: hidden;
   }
+}
+
+// Breaks long words and links that would otherwise cause overflow
+.full-post {
+  word-break: break-word;
 }
 
 // Hide extra whitespace created by the overflow hack above


### PR DESCRIPTION
The cause of the overflow is somewhere in the comment sections, but it isn't actually visibly overflowing, so simply hiding that overflow fixes the issue entirely.

[Video of scrolling the feed](https://i.imgur.com/RECJY1P.mp4) (looks the same in every other page I've tried) with fixes applied.

[Video of scrolling the feed](https://i.imgur.com/PUXx1bA.mp4) as Kitsu is currently.

Long words and links would not break correctly on iOS, which sometimes rendered parts of posts outside the viewport. Adding word-break: break-word fixes this as it forces long words to break if they would cause an overflow on its own line.

Fixed
![fixed](https://user-images.githubusercontent.com/16106839/114932471-d7739c00-9e37-11eb-902f-5cb1c6dd13fc.png)

Old
![old](https://user-images.githubusercontent.com/16106839/114932573-f2461080-9e37-11eb-9c3e-46aa8a6a3a8b.png)
