### PR TITLE
Remove weird wrap on tabbars

### DIFF
--- a/app/styles/layout/_navbar.scss
+++ b/app/styles/layout/_navbar.scss
@@ -131,6 +131,12 @@
   }
 
   @media (max-width: 767px) {
+    .container {
+      max-width: 100%;
+    }
+  }
+
+  @media (max-width: 767px) {
     .nav.navbar-nav {
       display: flex;
       justify-content: stretch;
@@ -144,6 +150,11 @@
     padding: 10px 20px;
     font-size: 14px;
     color: $body-text-color;
+
+    @media (max-width: 767px) {
+      min-width: max-content;
+    }
+
     @if $theme == "kitsu-light" {
       color: lighten($body-text-color, 35);
     }


### PR DESCRIPTION
No longer wraps the tabs if they have more than just one word

After fix
![After fix](https://user-images.githubusercontent.com/16106839/115039653-efe3c500-9ed0-11eb-8df5-b1cc624fae81.png)

Bugged version I introduced in a previously merged PR that is not yet deployed
![Bugged version ](https://user-images.githubusercontent.com/16106839/115039964-3a654180-9ed1-11eb-97b0-0ef7aa6a7cf8.png)


Currently deployed version
![Currently deployed version](https://user-images.githubusercontent.com/16106839/115039768-0be76680-9ed1-11eb-95ce-32a0f732ab1d.png)
