### PR TITLE
Change node version to 12-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15-alpine
+FROM node:12-alpine
 MAINTAINER Kitsu, Inc.
 
 RUN mkdir -p /opt/kitsu/client


### PR DESCRIPTION
The version we used previously, 15-alpine, was causing build errors.