### PR TITLE
Renamed "Personal Notes" to "Notes" to avoid confusion.

### DIFF
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -843,7 +843,7 @@ users:
       privacy: "Privacy"
       started: "Started"
       finished: "Finished"
-      notes: "Personal Notes"
+      notes: "Notes"
       remove: "Remove from Library"
       save: "Save Changes"
       saving: "Saving…"


### PR DESCRIPTION
Users mistakenly think that their notes will be private.