### PR TITLE
Forced streaming icons to be 25% of width so they are the same size.

### DIFF
--- a/app/templates/components/media/media-sidebar.hbs
+++ b/app/templates/components/media/media-sidebar.hbs
@@ -22,7 +22,7 @@
     {{else if getStreamersTask.last.value}}
       <ul class="nav">
         {{#each media.streamingLinks as |link|}}
-          <li>
+          <li style="width:25%;">
             <a href={{link.url}} target="_blank" rel="noopener noreferrer" class="hint--top hint--bounce hint--rounded" aria-label={{link.streamer.siteName}}>
               {{svg-jar (to-lower link.streamer.siteName)}}
             </a>


### PR DESCRIPTION
Fixes this issue:
https://kitsu.io/feedback/bugs/p/streaming-site-icons-not-aligned-correctly

/cc @hummingbird-me/staff
