### PR TITLE
Fixes the full-page posts overflow bug in Chrome and Safari

### DIFF
--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -1506,7 +1506,8 @@
 }
 
 .full-page-post {
-  width: 540px;
+  width: 100%;
+  max-width: 540px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/16106839/179312912-a5cdaffa-258d-44e3-b86c-1eab3f1e016c.png)

After
![image](https://user-images.githubusercontent.com/16106839/179312935-d3dea7fa-ed8b-43e0-9222-72bc9e790d2e.png)

