### PR TITLE
Update moment-timezones to latest 0.5.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "hoverintent": "~2.2.1",
     "loader.js": "~4.7.0",
     "moment": "~2.27.0",
-    "moment-timezone": "0.5.31",
+    "moment-timezone": "^0.5.40",
     "photoswipe": "~4.1.3",
     "postcss-flexbugs-fixes": "~4.2.0",
     "preferred-locale": "~1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6771,7 +6771,7 @@ ember-cli-moment-shim@3.8.0, ember-cli-moment-shim@^3.6.0:
     ember-get-config ""
     lodash.defaults "^4.2.0"
     moment "^2.19.3"
-    moment-timezone "^0.5.13"
+    moment-timezone "^0.5.40"
 
 ember-cli-node-assets@^0.1.4:
   version "0.1.6"
@@ -11474,10 +11474,11 @@ mktemp@~0.4.0:
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
   integrity sha1-bQUVYRyKjITkhKogABKbmOmB/ws=
 
-moment-timezone@0.5.31, moment-timezone@^0.5.13:
-  version "0.5.31"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.31.tgz#9c40d8c5026f0c7ab46eda3d63e49c155148de05"
-  integrity sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==
+
+moment-timezone@^0.5.40:
+  version "0.5.40"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.40.tgz#c148f5149fd91dd3e29bf481abc8830ecba16b89"
+  integrity sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
Updates moment-timezone package from version `0.5.31` -> `0.5.40`. 

According to a user, the TZ timezone `Europe/Kiev` should be `Europe/Kyiv`. The latest version of moment-timezones fixes this by adding `Europe/Kyiv` without removing the old `Europe/Kiev`.

I had to manually edit `yarn.lock` manually for this change as `ember-cli-moment-shim@3.8.0` uses `0.5.13` under the hood and is the package serving the timezones.

Image of timezone list after update
![image](https://user-images.githubusercontent.com/16106839/219709258-fb2a13c1-48a6-4cbe-839c-c2149326f6ab.png)