### PR TITLE
Small screen adjustments for mobile PWA usage

### DIFF
--- a/app/components/search-results.js
+++ b/app/components/search-results.js
@@ -37,6 +37,10 @@ export default Component.extend({
   algolia: service(),
   metrics: service(),
   raven: service(),
+  tetherConstraints: [{
+    to: 'window',
+    pin: true
+  }],
 
   init() {
     this._super(...arguments);

--- a/app/routes/feedback.js
+++ b/app/routes/feedback.js
@@ -16,5 +16,15 @@ export default Route.extend({
     if (get(transition, 'targetName') === 'feedback.index') {
       return this.transitionTo('feedback.bugs');
     }
+  },
+
+  activate() {
+    this._super(...arguments);
+    jQuery('body').addClass('feedback-page');
+  },
+
+  deactivate() {
+    this._super(...arguments);
+    jQuery('body').removeClass('feedback-page');
   }
 });

--- a/app/styles/base/_shame.scss
+++ b/app/styles/base/_shame.scss
@@ -84,7 +84,7 @@ body {
 }
 
 @media (max-width: 431px) {
-  body.settings-page {
+  body.settings-page, body.feedback-page {
     padding-top: 42px;
   }
 }

--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -1510,6 +1510,10 @@
   width: 100%;
   max-width: 540px;
   margin: 0 auto;
+
+  @media (max-width: 562px) {
+    margin: 0 12px;
+  }
 }
 
 // Stream review item

--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -120,7 +120,8 @@
   width: 100%;
   position: relative;
   @media (max-width: 768px) {
-    margin: 0;
+    margin-left: 8px;
+    margin-right: 8px;
   }
   &.quick-update-enabled {
     margin-top: 250px;

--- a/app/styles/layout/_navbar.scss
+++ b/app/styles/layout/_navbar.scss
@@ -329,6 +329,11 @@
 
 .search--drop {
   width: 350px;
+
+  @media (max-width: 452px) {
+    width: 300px;
+  }
+
   max-height: 90vh;
   background-color: $search-background-color;
   overflow: auto;
@@ -339,6 +344,12 @@
 .search--results {
   padding: 5px 0;
   .media {
+    @media (max-width: 550px) {
+      display: grid;
+      grid-template-columns: 62px 1fr min-content;
+      column-gap: 8px;
+    }
+
     padding: 5px 10px;
     &:hover {
       background: $search-results-hover-background;
@@ -364,6 +375,15 @@
   background-color: $search-header-background;
   padding: 10px;
   margin-bottom: 0px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  .search-close {
+    border: none;
+    background-color: inherit;
+    color: $body-text-color;
+  }
 }
 
 .search--group-header {

--- a/app/styles/layout/_navbar.scss
+++ b/app/styles/layout/_navbar.scss
@@ -382,7 +382,7 @@
   .search-close {
     border: none;
     background-color: inherit;
-    color: $body-text-color;
+    fill: $body-text-color;
   }
 }
 

--- a/app/styles/layout/_navbar.scss
+++ b/app/styles/layout/_navbar.scss
@@ -223,6 +223,10 @@
   &.navbar-nav .nav-item + .nav-item {
     margin-left: 10px;
   }
+
+  @media (max-width: 604px) {
+    padding-right: 10px;
+  }
 }
 .notifications {
   width: 25px;

--- a/app/styles/layout/_navbar.scss
+++ b/app/styles/layout/_navbar.scss
@@ -39,6 +39,7 @@
       }
       @media (max-width: 768px) {
         width: 100%;
+        max-height: 179px;
         padding: 0;
         margin: 0;
         left: -2px;

--- a/app/styles/layout/_sidebars.scss
+++ b/app/styles/layout/_sidebars.scss
@@ -4,6 +4,11 @@
   top: 0;
   bottom: 0;
   padding: 0 0 60px 15px;
+
+  @media (max-width: 652px) {
+    padding-left: 0;
+  }
+
   width: 300px;
   margin-right: -10px;
   > .sidebar-item:first-child {
@@ -175,6 +180,10 @@
     font-size: 12px;
     &:hover {
       color: $white;
+    }
+
+    @media (max-width: 380px) {
+      padding: 10px 40px;
     }
   }
 }
@@ -389,6 +398,25 @@
   font-size: 14px;
   p {
     white-space: pre-line;
+  }
+}
+
+@media (max-width: 652px) {
+  .cover-page {
+    .onboarding-mobile {
+      width: 96%;
+    }
+    .user-favorites {
+      padding-right: 16px;
+    }
+    .stream-onboarding {
+      margin-right: 16px;
+    }
+    .feed-stream {
+      >:last-child {
+        margin-right: 16px;
+      }
+    }
   }
 }
 

--- a/app/styles/layout/_sidebars.scss
+++ b/app/styles/layout/_sidebars.scss
@@ -417,6 +417,9 @@
         margin-right: 16px;
       }
     }
+    .user-stats {
+      padding-right: 16px;
+    }
   }
 }
 

--- a/app/styles/pages/_explore.scss
+++ b/app/styles/pages/_explore.scss
@@ -36,6 +36,11 @@
       }
     }
   }
+
+  @media (max-width: 524px) {
+    margin-left: 8px;
+    margin-right: 8px;
+  }
 }
 
 .explore-section {
@@ -69,6 +74,11 @@
     order: -1;
     width: 100%;
     max-width: 100%;
+
+    .card {
+      margin-left: 8px;
+      margin-right: 8px;
+    }
   }
 }
 

--- a/app/styles/pages/_groups.scss
+++ b/app/styles/pages/_groups.scss
@@ -266,6 +266,11 @@
   @media (max-width: 768px) {
     width: 100%;
   }
+
+  @media (max-width: 618px) {
+    margin-left: 12px;
+    margin-right: 12px;
+  }
 }
 
 .group-category-list {

--- a/app/styles/pages/_library.scss
+++ b/app/styles/pages/_library.scss
@@ -266,6 +266,11 @@
 }
 
 .library-content {
+  @media (max-width: 768px) {
+    margin-left: 8px;
+    margin-right: 8px;
+  }
+
   .media-browse {
     padding: 0;
     margin-bottom: 15px;
@@ -769,6 +774,13 @@
 }
 
 .library-empty-block {
+  h5 {
+    @media (max-width: 768px) {
+      margin-left: 8px;
+      margin-right: 8px;
+    }
+  }
+
   img {
     width: 200px;
     height: 200px;

--- a/app/styles/pages/_library.scss
+++ b/app/styles/pages/_library.scss
@@ -267,6 +267,7 @@
 
 .library-content {
   @media (max-width: 768px) {
+    width: 100%;
     margin-left: 8px;
     margin-right: 8px;
   }

--- a/app/styles/pages/_settings.scss
+++ b/app/styles/pages/_settings.scss
@@ -9,7 +9,13 @@
   width: 100%;
   margin-top: -38px;
   margin-bottom: 30px;
-  padding: 30px 0 0px;
+  padding: 30px 0 0;
+
+  @media (max-width: 608px) {
+    padding: 30px 12px 0 12px;
+    margin-bottom: 0;
+  }
+
   img {
     width: 40px;
     height: 40px;
@@ -96,6 +102,12 @@
   .form-group {
     padding-bottom: 20px;
     margin-bottom: 0;
+
+    .form-check-label {
+      &.link-facebook-button {
+        margin-left: auto;
+      }
+    }
   }
   small {
     color: #909090;

--- a/app/templates/components/application/site-header.hbs
+++ b/app/templates/components/application/site-header.hbs
@@ -69,7 +69,7 @@
         <ul class="nav navbar-nav">
           {{! Library }}
           {{#if session.hasUser}}
-            <li class="nav-item">
+            <li class="nav-item" data-toggle="collapse" data-target="#exCollapsingNavbar2">
               {{link-to (t "header.library") "users.library" session.account class="nav-link"}}
             </li>
           {{/if}}
@@ -84,7 +84,7 @@
             </div>
           </li>
           {{! Groups }}
-          <li class="nav-item">
+          <li class="nav-item" data-toggle="collapse" data-target="#exCollapsingNavbar2">
             {{link-to (t "header.groups") "groups.index" class="nav-link"}}
           </li>
           {{! Feedback}}

--- a/app/templates/components/application/site-header.hbs
+++ b/app/templates/components/application/site-header.hbs
@@ -78,7 +78,7 @@
             <a class="nav-link dropdown-toggle {{if isBrowseRoute "active"}}" href="#" data-toggle="dropdown" data-href-to-ignore=true>
               {{t "header.browse"}}
             </a>
-            <div class="dropdown-menu">
+            <div class="dropdown-menu" data-toggle="collapse" data-target="#exCollapsingNavbar2">
               <a class="dropdown-item" href={{href-to "explore.index" "anime"}}>{{t "header.anime"}}</a>
               <a class="dropdown-item" href={{href-to "explore.index" "manga"}}>{{t "header.manga"}}</a>
             </div>
@@ -92,7 +92,7 @@
             <a class="nav-link dropdown-toggle {{if isFeedbackRoute "active"}}" href="#" data-toggle="dropdown" data-href-to-ignore=true>
               {{t "header.feedback"}}
             </a>
-            <div class="dropdown-menu">
+            <div class="dropdown-menu" data-toggle="collapse" data-target="#exCollapsingNavbar2">
               <a class="dropdown-item" href={{href-to "feedback.bugs"}}>{{t "feedback.bugs"}}</a>
               <a class="dropdown-item" href={{href-to "feedback.feature-requests"}}>{{t "feedback.features"}}</a>
               <a class="dropdown-item" href="https://kitsu-stuff.com" target="_blank" rel="noopener">{{t "feedback.database"}}</a>

--- a/app/templates/components/search-results.hbs
+++ b/app/templates/components/search-results.hbs
@@ -6,9 +6,13 @@
     attachment=(or attachment "top right")
     targetAttachment=(or targetAttachment "bottom right")
     offset=(or offset "-30px 0px")
+    constraints=tetherConstraints
   }}
     <div class="search--drop">
-      <p class="search--header">{{t "components.search.header"}}</p>
+      <p class="search--header">
+        {{t "components.search.header"}}
+        <button class="search-close" onclick={{action "close"}}>🞪</button>
+      </p>
       <div style="overflow: auto">
         {{! media group }}
         {{search-results/group

--- a/app/templates/components/search-results.hbs
+++ b/app/templates/components/search-results.hbs
@@ -11,7 +11,11 @@
     <div class="search--drop">
       <p class="search--header">
         {{t "components.search.header"}}
-        <button class="search-close" onclick={{action "close"}}>🞪</button>
+        <button class="search-close" onclick={{action "close"}}>
+          <span class="svgIcon">
+            {{svg-jar "close"}}
+          </span>
+        </button>
       </p>
       <div style="overflow: auto">
         {{! media group }}

--- a/app/templates/settings/linked-accounts.hbs
+++ b/app/templates/settings/linked-accounts.hbs
@@ -6,20 +6,18 @@
   </div>
   <div class="container">
     <div class="form-group row">
-      <label class="col-xs-4 col-form-label">{{t "settings.linked-accounts.facebook"}}</label>
-      <div class="col-xs-8">
-        <label class="form-check-label">
-          {{#if session.account.facebookId}}
-            {{facebook-button text=(t "settings.linked-accounts.disconnect")
-              disabled=facebookTasks.isRunning
-              onclick=(perform disconnectFacebook)}}
-          {{else}}
-            {{facebook-button text=(t "settings.linked-accounts.connect")
-              disabled=facebookTasks.isRunning
-              onclick=(perform connectFacebook)}}
-          {{/if}}
-        </label>
-      </div>
+      <label class="col-form-label">{{t "settings.linked-accounts.facebook"}}</label>
+      <label class="form-check-label link-facebook-button">
+        {{#if session.account.facebookId}}
+          {{facebook-button text=(t "settings.linked-accounts.disconnect")
+            disabled=facebookTasks.isRunning
+            onclick=(perform disconnectFacebook)}}
+        {{else}}
+          {{facebook-button text=(t "settings.linked-accounts.connect")
+            disabled=facebookTasks.isRunning
+            onclick=(perform connectFacebook)}}
+        {{/if}}
+      </label>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
The current app on small screen sizes is not pretty and in some areas, not even usable. For users like myself that would prefer to use the PWA than the mobile app, this is unfortunate. This PR aims to make minor style adjustments where necessary in order to alleviate these issues!


| Before | After |
|--------|--------|
|      ![image](https://user-images.githubusercontent.com/31292294/222916273-edd0aef3-bc0c-4eb3-8f7c-f4448e284e9b.png)    |     ![image](https://user-images.githubusercontent.com/31292294/222915783-6f09b909-e840-476b-a311-16c15730fbd3.png)  |
|      ![image](https://user-images.githubusercontent.com/31292294/222916495-f591eced-c0a6-4a51-909f-19970ab89829.png)      |    ![image](https://user-images.githubusercontent.com/31292294/222915817-a324c7c6-d3c1-4497-b235-5aeba6bb8d07.png)        |
|     ![before](https://user-images.githubusercontent.com/31292294/222916439-36866776-9a03-4bec-bc40-fc6dc7a2d527.gif)       |     ![after](https://user-images.githubusercontent.com/31292294/222916056-028258f0-ff0e-4a4b-b824-62f645d40667.gif)       |
|   ![image](https://user-images.githubusercontent.com/31292294/222916240-cf08c6ab-3f51-4083-bc33-194eb75cf16b.png)         |     ![image](https://user-images.githubusercontent.com/31292294/222916095-e3bcc22a-f3fc-4129-9ade-41fc15a57ca2.png)       |
|     ![image](https://user-images.githubusercontent.com/31292294/222916523-63370f33-4389-4434-a4ea-de60dae386a3.png)       |       ![image](https://user-images.githubusercontent.com/31292294/222916135-533477b2-156b-4cfb-91d6-256c7ab6d079.png)     |


Changes proposed in this pull request that will only be noticeable on small screens:
- Add small margin to the feed page.
- Fix the menu opening animation.
- Add padding to the navbar buttons.
- Add small margin to library page content and fix loading skeleton width issue.
- Close the menu on click of library and groups buttons (the other two open a submenu).
- Make the search bar usable:
  - Reduce width.
  - Pin the popover to the screen so it no longer falls off the left side.
  - Change the layout of the items to make more effective use of space.
- Add padding to settings pages [TODO: gif]
- Fix spacing on profile / activity page [TODO: gif]
- Add padding to groups page [TODO: gif]
- Fix the enlarged feedback header (caused to due a hack in global css, this was fixed for other pages but not for feedback)  [TODO: gif]
- Add margins in explore pages [TODO: gif]


Changes proposed in this pull request that will always be noticeable (regardless of screen size):
- Added small button to close search results.
- Simplified HTML structure for settings/linked accounts; simpler template, works on small screens and produces the same result (plus/minus a few pixels) [TODO: gif]

`/cc @hummingbird-me/staff` 
^i will comment this when it is ready for review
