### PR TITLE
Ability to search for user tags on comment and post inputs

### DIFF
--- a/app/styles/layout/_feeds.scss
+++ b/app/styles/layout/_feeds.scss
@@ -1008,6 +1008,44 @@
   color: $input-text-color;
 }
 
+.userTagPopover {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background-color: $secondary-background-color;
+  color: $white;
+  border-radius: 0.25rem;
+  padding: 4px;
+
+  .userTagSearchResult {
+    display: grid;
+    grid-template-columns: 40px auto;
+    column-gap: 12px;
+    padding: 6px 10px;
+    border-radius: inherit;
+
+    &:hover {
+      background-color: lighten($secondary-background-color, 10);
+    }
+
+    .userAvatar img {
+      border-radius: 100%;
+    }
+
+    .userName {
+      line-height: 1;
+    }
+
+    .userTag {
+      color: $body-link-color;
+
+      &::before {
+        content: '@';
+      }
+    }
+  }
+}
+
 .stream-content {
   @include word-break();
   overflow: hidden;

--- a/app/templates/components/stream-feed/create-post.hbs
+++ b/app/templates/components/stream-feed/create-post.hbs
@@ -22,15 +22,42 @@
   {{#file-dropzone name="uploads" as |dropzone uploadQueue|}}
   {{! editor }}
   {{expanding-textarea content
-  update=(action (queue (action (mut content)) (action "processLinks")))
+  update=(action (queue (action (mut content)) (action "processLinks") (action "userTagSearch")))
   keyEvents=(hash
   13=(action "createPost")
+  9=(action "autocompleteUserTagOnTab")
+  27=(action "closeUserTagSearch")
   )
   onpaste=(action "paste")
   autofocus=true
   maxlength=maxLength
   class="stream-content-editor"
+  id="create-post-textarea"
   }}
+
+  {{#if (and users isUserSearchOpen)}}
+  <div>
+  {{#ember-tether
+    class=tooltipClass
+    target=".stream-content-editor"
+    attachment=(or attachment "top left")
+    targetAttachment=(or targetAttachment "bottom left")
+    offset=(or offset "-10px -20px")
+  }}
+  <div class="userTagPopover">
+    {{#each users as |user|}}
+    <div class="userTagSearchResult" onclick={{action "autocompleteUserTag" user.tag}}>
+      <div class="userAvatar">{{lazy-image src=user.avatar}}</div>
+      <div>
+        <div class="userName">{{ user.name }}</div>
+        <small class="userTag">{{ user.tag }}</small>
+      </div>
+    </div>
+    {{/each}}
+  </div>
+  {{/ember-tether}}
+  </div>
+  {{/if}}
 
   <div class="post-uploads">
     {{#if uploads}}

--- a/app/templates/components/stream-feed/items/post/comment-box.hbs
+++ b/app/templates/components/stream-feed/items/post/comment-box.hbs
@@ -1,8 +1,8 @@
 {{#file-dropzone name=(concat "comment-uploads-" elementId) disabled=dropzoneDisabled as |dropzone uploadQueue|}}
   <div class="comment-box-row">
     {{expanding-textarea content
-      update=(action (queue (action (mut content)) (action "processLinks")))
-      keyEvents=(hash 13=(action "submit"))
+      update=(action (queue (action (mut content)) (action "processLinks") (action "userTagSearch")))
+      keyEvents=(hash 13=(action "submit") 9=(action "autocompleteUserTagOnTab") 27=(action "closeUserTagSearch"))
       onpaste=(action "paste")
       disabled=onSubmit.isRunning
       rows="1"
@@ -10,7 +10,32 @@
         (if dropzone.valid (t "feeds.uploads.drop") (t "feeds.uploads.invalid"))
         (if uploadQueue.files.length (t "feeds.uploads.uploading" number=uploadQueue.files.length progress=uploadQueue.progress) placeholder))
       class=className
+      id=(concat "create-comment-textarea-" elementId)
     }}
+
+    {{#if (and users isUserSearchOpen)}}
+    <div>
+    {{#ember-tether
+      class=tooltipClass
+      target=(concat "#create-comment-textarea-" elementId)
+      attachment=(or attachment "top left")
+      targetAttachment=(or targetAttachment "bottom left")
+      offset=(or offset "-10px -20px")
+    }}
+    <div class="userTagPopover">
+      {{#each users as |user|}}
+      <div class="userTagSearchResult" onclick={{action "autocompleteUserTag" user.tag (concat "create-comment-textarea-" elementId)}}>
+        <div class="userAvatar">{{lazy-image src=user.avatar}}</div>
+        <div>
+          <div class="userName">{{ user.name }}</div>
+          <small class="userTag">{{ user.tag }}</small>
+        </div>
+      </div>
+      {{/each}}
+    </div>
+    {{/ember-tether}}
+    </div>
+    {{/if}}
 
     {{#unless (or upload embedUrl)}}
       {{#file-upload name=(concat "comment-uploads-" elementId)


### PR DESCRIPTION
## Description
When users are typing in the create post input or any comment box, they can type '@' and what immediately follows will be a user tag query. If they are satisfied with the top result, they may hit 'TAB' to autocomplete the top user tag. Otherwise, they may select a value from the dropdown of results that is tethered to the input box with a 5 second lifespan (before it is cleared)

### Gifs :)

![autocomplete-done-1](https://user-images.githubusercontent.com/31292294/223477706-849b08c0-5f2a-4be5-b1fd-8e03cd28f40d.gif)
![autocomplete-done-2](https://user-images.githubusercontent.com/31292294/223477719-7efa1440-1aaf-47dc-ba34-c027240f2628.gif)


/cc @hummingbird-me/staff
