### PR TITLE
Give redirect warning close button more area to make it easier to touch on mobile

### DIFF
--- a/app/components/application/redirect-warning.js
+++ b/app/components/application/redirect-warning.js
@@ -2,10 +2,11 @@ import Component from '@ember/component';
 import { get, set } from '@ember/object';
 
 export default Component.extend({
-  isShown: window.explainRedirect,
+  isShown: window.explainRedirect && !window.localStorage.getItem('hide-redirect-warning'),
 
   actions: {
     dismiss() {
+      window.localStorage.setItem('hide-redirect-warning', '1');
       set(this, 'isShown', false);
     }
   }

--- a/app/styles/layout/_navbar.scss
+++ b/app/styles/layout/_navbar.scss
@@ -549,12 +549,21 @@
 
   .inner {
     width: 100%;
+    margin-right: 3rem;
+  }
+
+  .row {
+    position: relative;
   }
 
   .dismiss {
-    float: right;
+    position: absolute;
+    top: -10px;
+    right: 0;
     color: white;
-    margin-right: 20px;
+    padding: 10px 1rem 2rem 2.5rem; /* make button big enough for touching it on mobile */
+    border: none;
+    background: none;
   }
 
   h5 {

--- a/app/templates/components/application/redirect-warning.hbs
+++ b/app/templates/components/application/redirect-warning.hbs
@@ -5,10 +5,10 @@
         <div class="inner">
           <h5>We've Moved!</h5>
           Don't be alarmed by the URL, we've moved from Kitsu.io to Kitsu.app
-          <span class="dismiss" {{action "dismiss"}}>
-            {{svg-jar "close"}}
-          </span>
         </div>
+        <button class="dismiss" {{action "dismiss"}}>
+          {{svg-jar "close"}}
+        </button>
       </div>
     </div>
   </aside>


### PR DESCRIPTION
I made the close button for the redirect warning a separate CSS "layer" (not really, but you'll see what I mean) and added a padding around the X so that you can hit it easier on mobile.

I also added a localStorage banner suppression which saves the hidden state of the banner (aside from using the redirect.io session stuff).
\* As this has already been fixed minutes before I commited my changes, I can remove that part if you want to. ;)

I hope this helps.

Screenshots for different sizes below (outline around button to represent click area, not visible in PR code) :
<img src="https://github.com/user-attachments/assets/e19cd386-0d6c-487b-873b-0e6f82663152" width="350" />
<img src="https://github.com/user-attachments/assets/93600850-123d-4420-b193-dd1e2d24d996" width="400" />
<img src="https://github.com/user-attachments/assets/6440f497-d824-46e4-a281-1a7a23423abd" width="450" />
<img src="https://github.com/user-attachments/assets/56bbdf9f-0b70-483b-ad26-61e7207420b1" width="650" />

Btw. this banner close button differs from the unicode "×" used in the mobile app banner below 🤔